### PR TITLE
fix: removes duplicate validator scores

### DIFF
--- a/src/api/routes/v1/validator-report.ts
+++ b/src/api/routes/v1/validator-report.ts
@@ -49,10 +49,10 @@ function formatResponse(response: DatabaseResponse): ScoreResponse {
 }
 
 /**
- * Reads nodes from database.
+ * Gets all daily score reports for a validator
  *
- * @param master_key - Master_key of validator.
- * @returns Locations of nodes crawled in the last 10 minutes.
+ * @param master_key - Master key of validator.
+ * @returns A promise that resolves to an array of ScoreResponse 
  */
 async function getReports(master_key: string): Promise<ScoreResponse[]> {
   return query('daily_agreement')
@@ -68,6 +68,7 @@ async function getReports(master_key: string): Promise<ScoreResponse[]> {
       'validators.master_key',
     )
     .where('validators.master_key', '=', master_key)
+    .andWhere('validators.revoked','=','false')
     .then((resp: DatabaseResponse[]) => resp.map(formatResponse))
 }
 
@@ -84,7 +85,6 @@ export default async function handleValidatorReport(
 ): Promise<void> {
   try {
     const master_key = req.params.publicKey
-
     const scores: ScoreResponse[] = await getReports(master_key)
 
     const response = {

--- a/src/api/routes/v1/validator.ts
+++ b/src/api/routes/v1/validator.ts
@@ -96,8 +96,7 @@ async function getValidators(): Promise<ValidatorResponse[]> {
       'master_key',
       'revoked',
     ])
-    .whereNotNull('signing_key')
-    .orWhereNotNull('master_key')
+    .where('revoked','=','false')
     .orderBy(['master_key', 'signing_key'])
     .then((res: dbResponse[]) => res.map(formatResponse))
 }


### PR DESCRIPTION
## High Level Overview of Change
Fixes duplicate scores and validator entries when manifests are changed. 

### Context of Change
When manifests change, the old validator entry stays in the database for 7 days before it is cleared out. This causes the `/network/validators/:publicKey/reports` endpoint to pick up the same daily score twice. I've included a check to make sure revoked signing_keys are not included in the daily_agreement query. I've also modified the saveManifest function to update the revoked column in the validators table as manifests are saved. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Testing
Tested by using dummy values in local db. I deleted the manifest entries for Bithomp's validator and set the 'revoked' column on the old validator entry to false. Then I ran the service and made sure that 'revoked' changes to true for the revoked signing_key. I also checked to see that the 