### PR TITLE
fix: fix issue where all nodes are in all networks

### DIFF
--- a/src/crawler/crawl.ts
+++ b/src/crawler/crawl.ts
@@ -14,7 +14,7 @@ const DEFAULT_PORT = 51235
 const IP_ADDRESS = /^::ffff:/u
 const BASE58_MAX_LENGTH = 50
 
-const LEDGER_RANGE = 10000
+const LEDGER_RANGE = 100000
 
 /**
  *

--- a/src/crawler/crawl.ts
+++ b/src/crawler/crawl.ts
@@ -97,7 +97,6 @@ class Crawler {
       network = 'dev'
       unl = config.vl_dev
     }
-    // console.log(unl)
     await this.crawlEndpoint(host, port, unl)
     await this.saveConnections(network)
   }
@@ -114,9 +113,6 @@ class Crawler {
         .where({ public_key: key })
       
       const arr = dbNetworks[0]?.networks?.split(',') || []
-      if (arr.length > 0) {
-        console.log(await query('crawls').select('*').where({ public_key: key }), network)
-      }
       arr.push(network)
       const networks = Array.from(new Set(arr)).join()
       void query('crawls')
@@ -187,7 +183,6 @@ class Crawler {
 
       const nodeNewestLedger = Crawler.getRecentLedger(node.complete_ledgers);
       if (nodeNewestLedger && !Crawler.ledgerInRange(newestLedger, nodeNewestLedger)) {
-        // console.log(host, node.ip, this_node.complete_ledgers, node)
         continue
       }
 

--- a/src/crawler/crawl.ts
+++ b/src/crawler/crawl.ts
@@ -59,6 +59,7 @@ class Crawler {
     log.info(`Starting crawl at ${host}:${port}`)
     let network = ''
     let unl = ''
+    if (host === 's1.ripple.com' || host === 's2.ripple.com' || host === 'p2p.livenet.ripple.com') {
       network = 'main'
       unl = config.vl_main
     }

--- a/src/crawler/crawl.ts
+++ b/src/crawler/crawl.ts
@@ -59,11 +59,9 @@ class Crawler {
       const intNodeNewestLedger = parseInt(nodeNewestLedger);
       if (intNewestLedger - LEDGER_RANGE < intNodeNewestLedger && intNodeNewestLedger < intNewestLedger + LEDGER_RANGE) {
         return true
-      } else {
-        return false
       }
     }
-    return true
+    return false
   }
 
   private static getRecentLedger(completeLedgers: string | undefined): string | undefined {
@@ -182,7 +180,7 @@ class Crawler {
       const normalizedPublicKey = Crawler.normalizePublicKey(node.public_key)
 
       const nodeNewestLedger = Crawler.getRecentLedger(node.complete_ledgers);
-      if (nodeNewestLedger && !Crawler.ledgerInRange(newestLedger, nodeNewestLedger)) {
+      if (!Crawler.ledgerInRange(newestLedger, nodeNewestLedger)) {
         continue
       }
 

--- a/src/crawler/network.ts
+++ b/src/crawler/network.ts
@@ -77,7 +77,11 @@ async function crawlNode(
         active_nodes,
       }
 
-      const node_unl = response.data?.unl.validator_sites[0].uri
+      const validatorSites = response.data?.unl.validator_sites
+      if (validatorSites.length === 0) {
+        return crawl
+      }
+      const node_unl = validatorSites[0].uri
 
       const unls = [`https://${unl}`];
       if (unl === 'vl.ripple.com') {

--- a/src/crawler/network.ts
+++ b/src/crawler/network.ts
@@ -84,7 +84,6 @@ async function crawlNode(
         unls.concat(['https://vl.xrplf.org', 'https://vl.coil.com'])
       }
       if (!unls.includes(node_unl)) {
-        console.log(`IGNORE ${host}: ${unl}`)
         throw new Error(`Node in the wrong network: ${host}, ${unl}`);
       }
 

--- a/src/crawler/network.ts
+++ b/src/crawler/network.ts
@@ -55,6 +55,7 @@ async function crawlNode(
         load_factor_server,
         uptime,
         build_version: version,
+        complete_ledgers,
       } = response.data?.server
 
       if (active_nodes === undefined) {
@@ -68,6 +69,7 @@ async function crawlNode(
         load_factor_server,
         uptime,
         version,
+        complete_ledgers
       }
 
       const crawl: Crawl = {
@@ -77,19 +79,23 @@ async function crawlNode(
 
       const node_unl = response.data?.unl.validator_sites[0].uri
 
-      if (node_unl != `https://${unl}`) {
-        console.log(`IGNORE ${host}`)
-        throw new Error(`Node in the wrong network: ${host}`);
+      const unls = [`https://${unl}`];
+      if (unl === 'vl.ripple.com') {
+        unls.concat(['https://vl.xrplf.org', 'https://vl.coil.com'])
+      }
+      if (!unls.includes(node_unl)) {
+        console.log(`IGNORE ${host}: ${unl}`)
+        throw new Error(`Node in the wrong network: ${host}, ${unl}`);
       }
 
       return crawl
     })
     .catch((error) => {
-      if (!error.isAxiosError) {
-        log.error(error)
-      }
       if (error.message.includes("wrong network")) {
         throw error
+      }
+      if (!error.isAxiosError) {
+        log.error(error)
       }
       return undefined
     })

--- a/src/shared/database/index.ts
+++ b/src/shared/database/index.ts
@@ -234,6 +234,10 @@ export async function destroy(): Promise<void> {
  * @returns Void.
  */
 export async function saveNode(node: Node): Promise<void> {
+  if (node.complete_ledgers && node.complete_ledgers.length > 255) {
+    const ledgersSplit = node.complete_ledgers.split(',')
+    node.complete_ledgers = ledgersSplit[ledgersSplit.length-1]
+  }
   query('crawls')
     .insert(node)
     .onConflict('public_key')


### PR DESCRIPTION
## High Level Overview of Change

This PR adds some walls between the networks while crawling, for misconfigured or old nodes.

In order for a node to be considered a part of a network, it must satisfy the following conditions:
* `complete_ledgers` must be available and must be in the same range of ledgers (since mainnet, devnet, and testnet all have different current ledger indices)
* If available, the UNL must be for the same network

### Context of Change

In the current `crawls` db of the VHS, all nodes are marked with all 3 networks.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.
