### PR TITLE
BREAKING: add new APIs to filter nodes and validators by network

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,11 +16,13 @@ There are 3 folders in `src`, corresponding to the 3 processes that the VHS runs
   * `/network/validator_reports`: Returns scores for the nodes that it has crawled in the last day.
   * `/network/topology`: Returns information about all the nodes that the crawler has crawled in the last hour.
   * `/network/topology/nodes`: Same as above.
-  * `/network/topology/nodes/:publicKey`: Returns information about a specific node.
+  * `/network/topology/nodes/:network`: Same as above, filtered to only return the nodes that are a part of `network`.
+  * `/network/topology/node/:publicKey`: Returns information about a specific node.
   * `/network/validators`: Returns information about all the validators that the VHS is paying attention to.
-  * `/network/validators/:publicKey`: Returns information about a specific validator.
-  * `/network/validators/:publicKey/manifests`: Returns the manifests of a specific validator.
-  * `/network/validators/:publicKey/reports`: Returns more detailed information about the reliability of a specific validator.
+  * `/network/validators/:network`: Same as above, filtered to only return the validators that are a part of `network`.
+  * `/network/validator/:publicKey`: Returns information about a specific validator.
+  * `/network/validator/:publicKey/manifests`: Returns the manifests of a specific validator.
+  * `/network/validator/:publicKey/reports`: Returns more detailed information about the reliability of a specific validator.
 
 
 ## SQL Table Schemas

--- a/src/api/routes/v1/index.ts
+++ b/src/api/routes/v1/index.ts
@@ -11,16 +11,16 @@ const api = createRouter()
 
 api.use('/health', handleHealth)
 api.use('/network/validator_reports', handleDailyScores)
+
+api.use('/network/topology/nodes/:network', handleNodes)
+api.use('/network/topology/nodes', handleNodes)
+api.use('/network/topology/node/:publicKey', handleNode)
 api.use('/network/topology', handleTopology)
 
-api.use('/network/topology/nodes', handleNodes)
-api.use('/network/topology/nodes/:network', handleNodes)
-api.use('/network/topology/node/:publicKey', handleNode)
-
-api.use('/network/validators', handleValidators)
-api.use('/network/validators/:network', handleValidators)
-api.use('/network/validator/:publicKey', handleValidator)
 api.use('/network/validator/:publicKey/reports', handleValidatorReport)
 api.use('/network/validator/:publicKey/manifests', handleValidatorManifest)
+api.use('/network/validators/:unl', handleValidators)
+api.use('/network/validator/:publicKey', handleValidator)
+api.use('/network/validators', handleValidators)
 
 export default api

--- a/src/api/routes/v1/index.ts
+++ b/src/api/routes/v1/index.ts
@@ -19,7 +19,7 @@ api.use('/network/topology', handleTopology)
 
 api.use('/network/validator/:publicKey/reports', handleValidatorReport)
 api.use('/network/validator/:publicKey/manifests', handleValidatorManifest)
-api.use('/network/validators/:unl', handleValidators)
+api.use('/network/validators/:network', handleValidators)
 api.use('/network/validator/:publicKey', handleValidator)
 api.use('/network/validators', handleValidators)
 

--- a/src/api/routes/v1/index.ts
+++ b/src/api/routes/v1/index.ts
@@ -14,15 +14,16 @@ api.use('/network/validator_reports', handleDailyScores)
 api.use('/network/topology', handleTopology)
 
 api.use('/network/topology/nodes/:publicKey', handleNode)
-api.use('/network/topology/nodes', handleNodes)
 // ^ This will be replaced - copied for easier migration
+api.use('/network/topology/nodes', handleNodes)
 api.use('/network/topology/node/:publicKey', handleNode)
 
 api.use('/network/validators/:publicKey/reports', handleValidatorReport)
 api.use('/network/validators/:publicKey/manifests', handleValidatorManifest)
 api.use('/network/validators/:publicKey', handleValidator)
-api.use('/network/validators', handleValidators)
 // ^ These will be replaced - copied for easier migration
+api.use('/network/validators', handleValidators)
+
 api.use('/network/validator/:publicKey', handleValidator)
 api.use('/network/validator/:publicKey/reports', handleValidatorReport)
 api.use('/network/validator/:publicKey/manifests', handleValidatorManifest)

--- a/src/api/routes/v1/index.ts
+++ b/src/api/routes/v1/index.ts
@@ -13,17 +13,12 @@ api.use('/health', handleHealth)
 api.use('/network/validator_reports', handleDailyScores)
 api.use('/network/topology', handleTopology)
 
-api.use('/network/topology/nodes/:publicKey', handleNode)
-// ^ This will be replaced - copied for easier migration
 api.use('/network/topology/nodes', handleNodes)
+api.use('/network/topology/nodes/:network', handleNodes)
 api.use('/network/topology/node/:publicKey', handleNode)
 
-api.use('/network/validators/:publicKey/reports', handleValidatorReport)
-api.use('/network/validators/:publicKey/manifests', handleValidatorManifest)
-api.use('/network/validators/:publicKey', handleValidator)
-// ^ These will be replaced - copied for easier migration
 api.use('/network/validators', handleValidators)
-
+api.use('/network/validators/:network', handleValidators)
 api.use('/network/validator/:publicKey', handleValidator)
 api.use('/network/validator/:publicKey/reports', handleValidatorReport)
 api.use('/network/validator/:publicKey/manifests', handleValidatorManifest)

--- a/src/api/routes/v1/index.ts
+++ b/src/api/routes/v1/index.ts
@@ -8,17 +8,23 @@ import { handleValidator, handleValidators } from './validator'
 import handleValidatorReport from './validator-report'
 
 const api = createRouter()
+
 api.use('/health', handleHealth)
-
-api.use('/network/topology', handleTopology)
-api.use('/network/topology/nodes', handleNodes)
-api.use('/network/topology/nodes/:publicKey', handleNode)
-
-api.use('/network/validators', handleValidators)
-api.use('/network/validators/:publicKey', handleValidator)
-api.use('/network/validators/:publicKey/manifests', handleValidatorManifest)
-api.use('/network/validators/:publicKey/reports', handleValidatorReport)
-
 api.use('/network/validator_reports', handleDailyScores)
+api.use('/network/topology', handleTopology)
+
+api.use('/network/topology/nodes/:publicKey', handleNode)
+api.use('/network/topology/nodes', handleNodes)
+// ^ This will be replaced - copied for easier migration
+api.use('/network/topology/node/:publicKey', handleNode)
+
+api.use('/network/validators/:publicKey/reports', handleValidatorReport)
+api.use('/network/validators/:publicKey/manifests', handleValidatorManifest)
+api.use('/network/validators/:publicKey', handleValidator)
+api.use('/network/validators', handleValidators)
+// ^ These will be replaced - copied for easier migration
+api.use('/network/validator/:publicKey', handleValidator)
+api.use('/network/validator/:publicKey/reports', handleValidatorReport)
+api.use('/network/validator/:publicKey/manifests', handleValidatorManifest)
 
 export default api

--- a/src/api/routes/v1/info.ts
+++ b/src/api/routes/v1/info.ts
@@ -12,14 +12,14 @@ const info = {
       example: 'https://data.xrpl.org/v1/network/topology/nodes',
     },
     {
-      action: 'Get Topology Node',
-      route: '/v1/network/topology/nodes/{pubkey}',
-      example: 'https://data.xrpl.org/v1/network/topology/nodes/{pubkey}',
+      action: 'Get Topology Nodes By Network',
+      route: '/v1/network/topology/nodes/{network}',
+      example: 'https://data.xrpl.org/v1/network/topology/nodes/{network}',
     },
     {
-      action: 'Get Validator',
-      route: '/v2/network/validators/{pubkey}',
-      example: 'https://data.xrpl.org/v1/network/validators/{pubkey}',
+      action: 'Get Topology Node',
+      route: '/v1/network/topology/node/{pubkey}',
+      example: 'https://data.xrpl.org/v1/network/topology/node/{pubkey}',
     },
     {
       action: 'Get Validators',
@@ -27,13 +27,23 @@ const info = {
       example: 'https://data.xrpl.org/v1/network/validators',
     },
     {
+      action: 'Get Validators By Network',
+      route: '/v2/network/validators/{network}',
+      example: 'https://data.xrpl.org/v1/network/validators/{network}',
+    },
+    {
+      action: 'Get Validator',
+      route: '/v2/network/validator/{pubkey}',
+      example: 'https://data.xrpl.org/v1/network/validator/{pubkey}',
+    },
+    {
       action: 'Get Validator Manifests',
-      route: '/v2/network/validators/{pubkey}/manifests',
+      route: '/v2/network/validator/{pubkey}/manifests',
       example: 'https://data.xrpl.org/v1/network/validators/{pubkey}/manifests',
     },
     {
       action: 'Get Single Validator Report',
-      route: '/v2/network/validators/{pubkey}/reports',
+      route: '/v2/network/validator/{pubkey}/reports',
       example: 'https://data.xrpl.org/v1/network/validators/{pubkey}/reports',
     },
     {

--- a/src/api/routes/v1/nodes.ts
+++ b/src/api/routes/v1/nodes.ts
@@ -191,19 +191,26 @@ export async function handleNode(req: Request, res: Response): Promise<void> {
 /**
  * Handles Nodes request.
  *
- * @param _u - Unused express request.
+ * @param req - Unused express request.
  * @param res - Express response.
  */
-export async function handleNodes(_u: Request, res: Response): Promise<void> {
+export async function handleNodes(req: Request, res: Response): Promise<void> {
   try {
     if (Date.now() - cache.time > 60 * 1000) {
       await cacheNodes()
     }
 
+    const { network } = req.params
+    const nodes =
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Necessary here
+      network == null
+        ? cache.nodes
+        : cache.nodes.filter((node) => node.networks?.includes(network))
+
     res.send({
       result: 'success',
-      count: cache.nodes.length,
-      nodes: cache.nodes,
+      count: nodes.length,
+      nodes,
     })
   } catch {
     res.send({ result: 'error', message: 'internal error' })

--- a/src/api/routes/v1/validator.ts
+++ b/src/api/routes/v1/validator.ts
@@ -265,8 +265,6 @@ export async function handleValidators(
     if (Date.now() - cache.time > 60 * 1000) {
       await cacheValidators()
     }
-    console.log(req.params)
-    console.log(cache.validators.length)
 
     const { network } = req.params
     const validators =

--- a/src/api/routes/v1/validator.ts
+++ b/src/api/routes/v1/validator.ts
@@ -265,13 +265,15 @@ export async function handleValidators(
     if (Date.now() - cache.time > 60 * 1000) {
       await cacheValidators()
     }
+    console.log(req.params)
+    console.log(cache.validators.length)
 
-    const { unl } = req.params
+    const { network } = req.params
     const validators =
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Necessary here
-      unl == null
+      network == null
         ? cache.validators
-        : cache.validators.filter((validator) => validator.unl === unl)
+        : cache.validators.filter((validator) => validator.chain === network)
 
     const response: ValidatorsResponse = {
       result: 'success',

--- a/src/api/routes/v1/validator.ts
+++ b/src/api/routes/v1/validator.ts
@@ -254,11 +254,11 @@ export async function handleValidator(
 /**
  * Handles Validators Request.
  *
- * @param _u - Express request.
+ * @param req - Express request.
  * @param res - Express response.
  */
 export async function handleValidators(
-  _u: Request,
+  req: Request,
   res: Response,
 ): Promise<void> {
   try {
@@ -266,10 +266,17 @@ export async function handleValidators(
       await cacheValidators()
     }
 
+    const { unl } = req.params
+    const validators =
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Necessary here
+      unl == null
+        ? cache.validators
+        : cache.validators.filter((validator) => validator.unl === unl)
+
     const response: ValidatorsResponse = {
       result: 'success',
-      count: cache.validators.length,
-      validators: cache.validators,
+      count: validators.length,
+      validators,
     }
 
     res.send(response)


### PR DESCRIPTION
## High Level Overview of Change

This PR adds new API methods to filter nodes and validators by what network they are in (mainnet/testnet/devnet). The existing API calls are also modified a bit, to be named to better represent what they do.

### Context of Change

Prep for sidechain support

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.