### PR TITLE
fix: better use of network data

### DIFF
--- a/src/shared/utils/networks.ts
+++ b/src/shared/utils/networks.ts
@@ -26,7 +26,7 @@ const networks: Network[] = [
     network: 'main',
     entry: config.mainnet_p2p_server,
     port: 51235,
-    unls: ['vl.ripple.com', 'vl.xrplf.org', 'vl.coil.com'],
+    unls: mainnetUnls,
   },
   {
     network: 'test',


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes a few issues that were missed in #29. Namely:
* The list of mainnet UNLs was hardcoded, and wasn't actually used in the network list.
* The list of UNLs was generated again in `crawlEndpoint`, instead of just using the initial list from `networks`.

### Context of Change

Fixing issues missed in #29

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.
