### PR TITLE
fix: remove https from UNL

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
   collectCoverage: true,
   maxWorkers: 1,
   coverageReporters: ['text', 'text-summary', 'html'],
+  setupFiles: ['dotenv/config'],
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "startCrawlerDev": "ts-node-dev --transpile-only ./src/crawler/index.ts | ./node_modules/.bin/bunyan ",
     "startApiDev": "ts-node-dev --transpile-only ./src/api/index.ts | ./node_modules/.bin/bunyan",
     "startConnectionsDev": "ts-node-dev --transpile-only ./src/connection-manager/index.ts | ./node_modules/.bin/bunyan",
-    "test": "jest --setupFiles dotenv/config",
+    "test": "jest",
     "prepublishOnly": "npm run build"
   },
   "files": [

--- a/src/crawler/network.ts
+++ b/src/crawler/network.ts
@@ -75,7 +75,10 @@ async function crawlNode(
       const crawl: Crawl = {
         this_node,
         active_nodes,
-        node_unl: validatorSites.length > 0 ? validatorSites[0].uri : undefined,
+        node_unl:
+          validatorSites.length > 0
+            ? validatorSites[0].uri.replace(/^https?:\/\//u, '')
+            : undefined,
       }
 
       return crawl

--- a/test/crawler/crawler.test.ts
+++ b/test/crawler/crawler.test.ts
@@ -33,7 +33,7 @@ async function crawl(ip: string): Promise<void> {
   await new Crawler().crawl({
     network: 'main',
     entry: ip,
-    unls: [],
+    unls: ['vl.fake.example.com'],
   })
 }
 

--- a/test/crawler/fixtures/three-node-crawl.json
+++ b/test/crawler/fixtures/three-node-crawl.json
@@ -25,6 +25,17 @@
         "load_factor_server": "1",
         "uptime": "1",
         "version": "1.6.0"
+      },
+      "unl": {
+        "validator_sites": [
+          {
+            "last_refresh_status": "same_sequence",
+            "last_refresh_time": "2022-May-03 21:59:20.652097009 UTC",
+            "next_refresh_time": "2022-May-03 22:04:20.636643972 UTC",
+            "refresh_interval_min": 5,
+            "uri":"https://vl.fake.example.com"
+          }
+        ]
       }
     },
     "1.1.1.13": {


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.


The UNL name pulled from `/crawl` has `https` appended to it. The UNL lists in the VHS do not.

### Context of Change

Crawls were finding 0 nodes.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Works locally. Modifies a test to check for this.
