### PR TITLE
feat: use a table for networks instead of hardcoding

### DIFF
--- a/src/api/routes/v1/nodes.ts
+++ b/src/api/routes/v1/nodes.ts
@@ -205,7 +205,7 @@ export async function handleNodes(req: Request, res: Response): Promise<void> {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Necessary here
       network == null
         ? cache.nodes
-        : cache.nodes.filter((node) => node.networks?.includes(network))
+        : cache.nodes.filter((node) => node.networks === network)
 
     res.send({
       result: 'success',

--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -1,8 +1,7 @@
 import 'dotenv/config'
 
 import Crawler from '../crawler/crawl'
-import { setupTables } from '../shared/database'
-import networks from '../shared/utils/networks'
+import { setupTables, getNetworks } from '../shared/database'
 
 import agreement from './agreement'
 import startConnections from './connections'
@@ -13,9 +12,10 @@ async function start(): Promise<void> {
   // Migrate manifests from the legacy database. This will be removed once the service has collected enough manifests.
   // await migrate()
   const promises = []
-  for (const entry of networks) {
+  const networks = await getNetworks()
+  for (const network of networks) {
     const crawler = new Crawler()
-    promises.push(crawler.crawl(entry))
+    promises.push(crawler.crawl(network))
   }
   await Promise.all(promises)
   await startConnections()

--- a/src/connection-manager/manifests.ts
+++ b/src/connection-manager/manifests.ts
@@ -34,7 +34,7 @@ let jobsStarted = false
  */
 async function getFirstUNL(networkName: string): Promise<string> {
   const networks = await getNetworks()
-  const network = networks.filter((ntwk) => ntwk.network === networkName)[0]
+  const network = networks.filter((ntwk) => ntwk.id === networkName)[0]
   return network.unls[0]
 }
 

--- a/src/crawler/crawl.ts
+++ b/src/crawler/crawl.ts
@@ -103,7 +103,7 @@ class Crawler {
     log.info(`Starting crawl at ${network.entry}:${port}`)
 
     await this.crawlEndpoint(network.entry, port, network.unls)
-    await this.saveConnections(network.network)
+    await this.saveConnections(network.id)
   }
 
   /**

--- a/src/crawler/crawl.ts
+++ b/src/crawler/crawl.ts
@@ -2,9 +2,9 @@ import moment, { Moment } from 'moment'
 import { encodeNodePublic } from 'ripple-address-codec'
 
 import { query, saveNode } from '../shared/database'
+import { Network } from '../shared/database/networks'
 import { Crawl } from '../shared/types'
 import logger from '../shared/utils/logger'
-import { Network } from '../shared/utils/networks'
 
 import crawlNode from './network'
 

--- a/src/crawler/index.ts
+++ b/src/crawler/index.ts
@@ -1,9 +1,8 @@
 import 'dotenv/config'
 import moment from 'moment'
 
-import { setupTables } from '../shared/database'
+import { setupTables, getNetworks } from '../shared/database'
 import logger from '../shared/utils/logger'
-import networks from '../shared/utils/networks'
 
 import Crawler from './crawl'
 import locate from './locate'
@@ -16,6 +15,7 @@ async function crawl(): Promise<void> {
   const crawlers: Crawler[] = []
   const startCrawl = moment.utc()
   const promises = []
+  const networks = await getNetworks()
   for (const entry of networks) {
     const crawler = new Crawler()
     crawlers.push(crawler)

--- a/src/shared/database/index.ts
+++ b/src/shared/database/index.ts
@@ -7,7 +7,6 @@ import {
   DatabaseNetwork,
 } from '../types'
 import logger from '../utils/logger'
-import { Network } from '../utils/networks'
 
 import {
   saveHourlyAgreement,
@@ -18,6 +17,7 @@ import {
   update24HourValidatorAgreement,
   update30DayValidatorAgreement,
 } from './agreement'
+import { Network } from './networks'
 import setupTables from './setup'
 import { db, tearDown, query, destroy } from './utils'
 

--- a/src/shared/database/index.ts
+++ b/src/shared/database/index.ts
@@ -1,14 +1,10 @@
-import { QueryBuilder } from 'knex'
-
 import {
   Node,
   DatabaseManifest,
   DatabaseValidator,
   Validator,
   Location,
-  Chain,
 } from '../types'
-import { getLists, overlaps } from '../utils'
 import logger from '../utils/logger'
 import { Network } from '../utils/networks'
 
@@ -26,14 +22,6 @@ import { db, tearDown, query, destroy } from './utils'
 
 const log = logger({ name: 'database' })
 const IP_REGEX = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/u
-
-let lists: Record<string, Set<string>> | undefined
-
-getLists()
-  .then((ret) => {
-    lists = ret
-  })
-  .catch((err) => log.error('Error getting validator lists', err))
 
 /**
  * Get the list of networks.
@@ -253,35 +241,6 @@ export async function purgeHourlyAgreementScores(): Promise<void> {
     .delete('*')
     .where('start', '<', thirtyDaysAgo)
     .catch((err) => log.error('Error Purging Hourly Agreement Scores', err))
-}
-
-/**
- * Saves the chain id for each validator known to be in a given chain.
- *
- * @param chain - A chain object.
- * @returns Void.
- */
-export async function saveValidatorChains(chain: Chain): Promise<void> {
-  let id = chain.id
-  if (lists != null) {
-    Object.entries(lists).forEach(([network, set]) => {
-      if (overlaps(chain.validators, set)) {
-        id = network
-      }
-    })
-  }
-
-  const promises: QueryBuilder[] = []
-  chain.validators.forEach((signing_key) => {
-    promises.push(
-      query('validators').where({ signing_key }).update({ chain: id }),
-    )
-  })
-  try {
-    await Promise.all(promises)
-  } catch (err: unknown) {
-    log.error('Error saving validator chains', err)
-  }
 }
 
 export {

--- a/src/shared/database/index.ts
+++ b/src/shared/database/index.ts
@@ -10,6 +10,7 @@ import {
 } from '../types'
 import { getLists, overlaps } from '../utils'
 import logger from '../utils/logger'
+import { Network } from '../utils/networks'
 
 import {
   saveHourlyAgreement,
@@ -33,6 +34,17 @@ getLists()
     lists = ret
   })
   .catch((err) => log.error('Error getting validator lists', err))
+
+/**
+ * Get the list of networks.
+ *
+ * @returns The list of networks.
+ */
+export async function getNetworks(): Promise<Network[]> {
+  return query('networks')
+    .select('*')
+    .then((resp: Network[]) => resp)
+}
 
 /**
  * Saves a Node to database.

--- a/src/shared/database/index.ts
+++ b/src/shared/database/index.ts
@@ -4,6 +4,7 @@ import {
   DatabaseValidator,
   Validator,
   Location,
+  DatabaseNetwork,
 } from '../types'
 import logger from '../utils/logger'
 import { Network } from '../utils/networks'
@@ -31,7 +32,14 @@ const IP_REGEX = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/u
 export async function getNetworks(): Promise<Network[]> {
   return query('networks')
     .select('*')
-    .then((resp: Network[]) => resp)
+    .then((resp: DatabaseNetwork[]) => {
+      return resp.map((network) => {
+        return {
+          ...network,
+          unls: network.unls.split(','),
+        }
+      })
+    })
 }
 
 /**

--- a/src/shared/database/networks.ts
+++ b/src/shared/database/networks.ts
@@ -1,4 +1,4 @@
-import config from './config'
+import config from '../utils/config'
 
 interface Network {
   network: string

--- a/src/shared/database/networks.ts
+++ b/src/shared/database/networks.ts
@@ -1,7 +1,7 @@
 import config from '../utils/config'
 
 interface Network {
-  network: string
+  id: string
   port?: number
   entry: string
   unls: string[]
@@ -23,25 +23,25 @@ if (config.mainnet_unl == null) {
 
 const networks: Network[] = [
   {
-    network: 'main',
+    id: 'main',
     entry: config.mainnet_p2p_server,
     port: 51235,
     unls: mainnetUnls,
   },
   {
-    network: 'test',
+    id: 'test',
     entry: 's.altnet.rippletest.net',
     port: 51235,
     unls: ['vl.altnet.rippletest.net'],
   },
   {
-    network: 'dev',
+    id: 'dev',
     entry: 's.devnet.rippletest.net',
     port: 51235,
     unls: ['vl.devnet.rippletest.net'],
   },
   {
-    network: 'nft-dev',
+    id: 'nft-dev',
     entry: 'xls20-sandbox.rippletest.net',
     port: 51235,
     unls: ['nftvalidators.s3.us-west-2.amazonaws.com/index.json'],

--- a/src/shared/database/setup.ts
+++ b/src/shared/database/setup.ts
@@ -1,6 +1,6 @@
 import logger from '../utils/logger'
-import networks from '../utils/networks'
 
+import networks from './networks'
 import { db, query } from './utils'
 
 const log = logger({ name: 'database' })

--- a/src/shared/database/setup.ts
+++ b/src/shared/database/setup.ts
@@ -173,6 +173,5 @@ async function setupNetworksTable(): Promise<void> {
         })
         .catch((err: Error) => log.error(err.message))
     })
-    // TODO: populate with default network data
   }
 }

--- a/src/shared/database/setup.ts
+++ b/src/shared/database/setup.ts
@@ -157,8 +157,10 @@ async function setupNetworksTable(): Promise<void> {
   const hasNetworks = await db().schema.hasTable('networks')
   if (!hasNetworks) {
     await db().schema.createTable('networks', (table) => {
-      table.string('entry')
       table.string('network')
+      table.string('entry')
+      table.integer('port')
+      table.string('unls')
       table.primary(['entry'])
     })
     networks.forEach((network) => {
@@ -166,6 +168,8 @@ async function setupNetworksTable(): Promise<void> {
         .insert({
           entry: network.entry,
           network: network.network,
+          port: network.port,
+          unls: network.unls.join(','),
         })
         .catch((err: Error) => log.error(err.message))
     })

--- a/src/shared/database/setup.ts
+++ b/src/shared/database/setup.ts
@@ -157,7 +157,7 @@ async function setupNetworksTable(): Promise<void> {
   const hasNetworks = await db().schema.hasTable('networks')
   if (!hasNetworks) {
     await db().schema.createTable('networks', (table) => {
-      table.string('network')
+      table.string('id')
       table.string('entry')
       table.integer('port')
       table.string('unls')
@@ -166,8 +166,8 @@ async function setupNetworksTable(): Promise<void> {
     networks.forEach((network) => {
       query('networks')
         .insert({
+          id: network.id,
           entry: network.entry,
-          network: network.network,
           port: network.port,
           unls: network.unls.join(','),
         })

--- a/src/shared/database/setup.ts
+++ b/src/shared/database/setup.ts
@@ -1,4 +1,9 @@
-import { db } from './utils'
+import logger from '../utils/logger'
+import networks from '../utils/networks'
+
+import { db, query } from './utils'
+
+const log = logger({ name: 'database' })
 
 /**
  * Setup tables in database.
@@ -13,6 +18,7 @@ export default async function setupTables(): Promise<void> {
   await setupValidatorsTable()
   await setupHourlyAgreementTable()
   await setupDailyAgreementTable()
+  await setupNetworksTable()
 }
 
 async function setupCrawlsTable(): Promise<void> {
@@ -144,5 +150,25 @@ async function setupDailyAgreementTable(): Promise<void> {
       table.json('agreement')
       table.primary(['main_key', 'day'])
     })
+  }
+}
+
+async function setupNetworksTable(): Promise<void> {
+  const hasNetworks = await db().schema.hasTable('networks')
+  if (!hasNetworks) {
+    await db().schema.createTable('networks', (table) => {
+      table.string('entry')
+      table.string('network')
+      table.primary(['entry'])
+    })
+    networks.forEach((network) => {
+      query('networks')
+        .insert({
+          entry: network.entry,
+          network: network.network,
+        })
+        .catch((err: Error) => log.error(err.message))
+    })
+    // TODO: populate with default network data
   }
 }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -103,9 +103,9 @@ interface DatabaseValidator extends Validator {
 }
 
 interface DatabaseNetwork {
-  network: string
-  port?: number
+  id: string
   entry: string
+  port?: number
   unls: string
 }
 

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -102,6 +102,13 @@ interface DatabaseValidator extends Validator {
   updated: string
 }
 
+interface DatabaseNetwork {
+  network: string
+  port?: number
+  entry: string
+  unls: string
+}
+
 // This is the shape returned by vl.ripple.com
 interface UNL {
   public_key: string
@@ -160,6 +167,7 @@ export {
   UNLBlob,
   UNLValidator,
   DatabaseManifest,
+  DatabaseNetwork,
   HourlyAgreement,
   DatabaseValidator,
   Validator,

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,11 +1,11 @@
 import axios, { AxiosRequestConfig } from 'axios'
 import { normalizeManifest } from 'xrpl-validator-domains'
 
+import { getNetworks } from '../database'
 import { UNL, UNLBlob, UNLValidator } from '../types'
 
 import config from './config'
 import logger from './logger'
-import networks from './networks'
 
 const log = logger({ name: 'utils' })
 
@@ -94,6 +94,7 @@ function blobToValidators(blob: UNLBlob): Set<string> {
 export async function getLists(): Promise<Record<string, Set<string>>> {
   const lists = {}
   const promises: Array<Promise<void>> = []
+  const networks = await getNetworks()
   networks.forEach(async (network) => {
     promises.push(
       fetchValidatorList(network.unls[0]).then((blob) => {

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -99,7 +99,7 @@ export async function getLists(): Promise<Record<string, Set<string>>> {
     promises.push(
       fetchValidatorList(network.unls[0]).then((blob) => {
         Object.assign(lists, {
-          [network.network]: blobToValidators(blob),
+          [network.id]: blobToValidators(blob),
         })
       }),
     )

--- a/src/shared/utils/networks.ts
+++ b/src/shared/utils/networks.ts
@@ -36,7 +36,7 @@ const networks: Network[] = [
   },
   {
     network: 'dev',
-    entry: 's.devnet.ripple.test.net',
+    entry: 's.devnet.rippletest.net',
     port: 51235,
     unls: ['vl.devnet.rippletest.net'],
   },

--- a/test/crawler/crawler.test.ts
+++ b/test/crawler/crawler.test.ts
@@ -31,7 +31,7 @@ function mock(): void {
 
 async function crawl(ip: string): Promise<void> {
   await new Crawler().crawl({
-    network: 'main',
+    id: 'main',
     entry: ip,
     unls: ['vl.fake.example.com'],
   })

--- a/test/manifests/manifests.test.ts
+++ b/test/manifests/manifests.test.ts
@@ -12,8 +12,8 @@ import {
   setupTables,
   tearDown,
 } from '../../src/shared/database'
+import networks from '../../src/shared/database/networks'
 import config from '../../src/shared/utils/config'
-import networks from '../../src/shared/utils/networks'
 
 import unl1 from './fixtures/unl-response1.json'
 import unl2 from './fixtures/unl-response2.json'


### PR DESCRIPTION
## High Level Overview of Change

This PR switches from using a hardcoded list for the networks to using a database (which is initially populated by the hardcoded list). 

### Context of Change

Sidechain work - it no longer needs to be a code change to add another network

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Works locally.

## Future Tasks
* Add an API endpoint to add networks to the db
