### PR TITLE
feat: add new API endpoint to fetch network ID

### DIFF
--- a/src/api/routes/v1/add-entry.ts
+++ b/src/api/routes/v1/add-entry.ts
@@ -60,13 +60,13 @@ async function addNode(url: string, unl: string | null): Promise<void> {
     .select('network')
     .orderBy('network')
   const maxNetwork =
-    currentNetworks[currentNetworks.length - networks.length - 1].network
+    currentNetworks[currentNetworks.length - networks.length - 1]?.network ?? 0
   console.log(currentNetworks, maxNetwork)
   await query('networks').insert({
     network: Number(maxNetwork) + 1,
     entry: url,
     port: 51235,
-    unls: unl,
+    unls: unl ?? '',
   })
 }
 
@@ -92,7 +92,7 @@ export default async function addEntry(
     if (node_unl != null && (await isUnlRecorded(node_unl))) {
       return res.send({
         result: 'error',
-        message: 'node part of an existing network',
+        message: 'node UNL part of an existing network',
       })
     }
 
@@ -101,7 +101,7 @@ export default async function addEntry(
     if (await isPublicKeyRecorded(public_key)) {
       return res.send({
         result: 'error',
-        message: 'node part of an existing network2',
+        message: 'node public key part of an existing network',
       })
     }
     // add node to networks list

--- a/src/api/routes/v1/add-entry.ts
+++ b/src/api/routes/v1/add-entry.ts
@@ -3,8 +3,8 @@ import { Request, Response } from 'express'
 import Crawler from '../../../crawler/crawl'
 import crawlNode from '../../../crawler/network'
 import { query } from '../../../shared/database'
+import networks, { Network } from '../../../shared/database/networks'
 import { Crawl } from '../../../shared/types'
-import networks, { Network } from '../../../shared/utils/networks'
 
 const CRAWL_PORTS = [51235, 2459, 30001]
 

--- a/src/api/routes/v1/add-entry.ts
+++ b/src/api/routes/v1/add-entry.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express'
 
-import crawlNetwork from '../../../crawler'
 import Crawler from '../../../crawler/crawl'
 import crawlNode from '../../../crawler/network'
 import { query } from '../../../shared/database'
@@ -10,7 +9,11 @@ import networks, { Network } from '../../../shared/utils/networks'
 const CRAWL_PORTS = [51235, 2459, 30001]
 
 /**
- * @param host
+ * Fetches the crawl data for the node.
+ *
+ * @param host - The host URL to crawl.
+ * @returns The crawl data from the node.
+ * @throws If none of the possible crawl ports work.
  */
 async function fetchCrawls(host: string): Promise<Crawl> {
   const promises = []
@@ -27,7 +30,10 @@ async function fetchCrawls(host: string): Promise<Crawl> {
 }
 
 /**
- * @param unl
+ * Checks whether the UNL of the node is recorded in the networks table.
+ *
+ * @param unl - The UNL of the node.
+ * @returns Whether the UNL of the node has been seen before.
  */
 async function isUnlRecorded(unl: string): Promise<boolean> {
   const result = await query('networks')
@@ -37,7 +43,10 @@ async function isUnlRecorded(unl: string): Promise<boolean> {
 }
 
 /**
- * @param publicKey
+ * Checks whether the public key of the node is recorded in the crawls table.
+ *
+ * @param publicKey - The public key of the node.
+ * @returns Whether the public key of the node has been seen before.
  */
 async function isPublicKeyRecorded(publicKey: string): Promise<boolean> {
   const result = await query('crawls')
@@ -47,8 +56,10 @@ async function isPublicKeyRecorded(publicKey: string): Promise<boolean> {
 }
 
 /**
- * @param url
- * @param unl
+ * Adds the node (and its corresponding network) to the networks table.
+ *
+ * @param url - The URL endpoint of the node.
+ * @param unl - The UNL of the node.
  */
 async function addNode(url: string, unl: string | null): Promise<void> {
   const currentNetworks = await query('networks')
@@ -76,6 +87,7 @@ async function addNode(url: string, unl: string | null): Promise<void> {
  *
  * @param req - Express request.
  * @param res - Express response.
+ * @returns The Express response.
  */
 export default async function addEntry(
   req: Request,
@@ -86,7 +98,6 @@ export default async function addEntry(
 
     // fetch crawl
     const crawl = await fetchCrawls(entryUrl)
-    console.log(crawl.this_node)
 
     // check UNL
     const { node_unl } = crawl

--- a/src/api/routes/v1/add-entry.ts
+++ b/src/api/routes/v1/add-entry.ts
@@ -1,0 +1,116 @@
+import { Request, Response } from 'express'
+
+import crawlNode from '../../../crawler/network'
+import { query } from '../../../shared/database'
+import { Crawl } from '../../../shared/types'
+import networks from '../../../shared/utils/networks'
+
+const CRAWL_PORTS = [51235, 2459, 30001]
+
+/**
+ * @param value
+ */
+function isNumeric(value) {
+  return /^-?\d+$/.test(value)
+}
+
+/**
+ * @param host
+ */
+async function fetchCrawls(host: string): Promise<Crawl> {
+  const promises = []
+  for (const port of CRAWL_PORTS) {
+    promises.push(crawlNode(host, port))
+  }
+  const results = await Promise.all(promises)
+  for (const result of results) {
+    if (result != null) {
+      return result
+    }
+  }
+  throw new Error('node could not be crawled')
+}
+
+/**
+ * @param unl
+ */
+async function isUnlRecorded(unl: string): Promise<boolean> {
+  const result = await query('networks')
+    .select('network')
+    .where('unls', 'like', `%${unl}%`)
+  return result.length > 0
+}
+
+/**
+ * @param publicKey
+ */
+async function isPublicKeyRecorded(publicKey: string): Promise<boolean> {
+  const result = await query('crawls')
+    .select('public_key')
+    .where('public_key', '=', publicKey)
+  return result.length > 0
+}
+
+/**
+ * @param url
+ * @param unl
+ */
+async function addNode(url: string, unl: string | null): Promise<void> {
+  const currentNetworks = await query('networks')
+    .select('network')
+    .orderBy('network')
+  const maxNetwork =
+    currentNetworks[currentNetworks.length - networks.length - 1].network
+  console.log(currentNetworks, maxNetwork)
+  await query('networks').insert({
+    network: Number(maxNetwork) + 1,
+    entry: url,
+    port: 51235,
+    unls: unl,
+  })
+}
+
+/**
+ * Add entry to new network.
+ *
+ * @param req - Express request.
+ * @param res - Express response.
+ */
+export default async function addEntry(
+  req: Request,
+  res: Response,
+): Promise<Response> {
+  try {
+    const { entryUrl } = req.params
+
+    // fetch crawl
+    const crawl = await fetchCrawls(entryUrl)
+    console.log(crawl.this_node)
+
+    // check UNL
+    const { node_unl } = crawl
+    if (node_unl != null && (await isUnlRecorded(node_unl))) {
+      return res.send({
+        result: 'error',
+        message: 'node part of an existing network',
+      })
+    }
+
+    // check if node public key is already recorded
+    const { public_key } = crawl.this_node
+    if (await isPublicKeyRecorded(public_key)) {
+      return res.send({
+        result: 'error',
+        message: 'node part of an existing network2',
+      })
+    }
+    // add node to networks list
+    await addNode(entryUrl, node_unl)
+
+    return res.send({
+      result: 'success',
+    })
+  } catch (err) {
+    return res.send({ result: 'error', message: err.message })
+  }
+}

--- a/src/api/routes/v1/get-network.ts
+++ b/src/api/routes/v1/get-network.ts
@@ -185,7 +185,7 @@ async function addNode(url: string, unl: string | null): Promise<string> {
 }
 
 /**
- * Add entry to new network.
+ * Fetch network ID from network entry. If the network doesn't exist, adds it with a new ID.
  *
  * @param req - Express request.
  * @param res - Express response.

--- a/src/api/routes/v1/get-network.ts
+++ b/src/api/routes/v1/get-network.ts
@@ -210,7 +210,6 @@ export default async function getNetwork(
         return res.send({
           result: 'success',
           network: unlNetwork,
-          created: false,
         })
       }
     }
@@ -222,7 +221,6 @@ export default async function getNetwork(
       return res.send({
         result: 'success',
         network: publicKeyNetwork,
-        created: false,
       })
     }
     // add node to networks list
@@ -231,7 +229,6 @@ export default async function getNetwork(
     return res.send({
       result: 'success',
       network: newNetwork,
-      created: true,
     })
   } catch (err) {
     log.error(err.stack)

--- a/src/api/routes/v1/get-network.ts
+++ b/src/api/routes/v1/get-network.ts
@@ -100,9 +100,9 @@ async function fetchCrawls(host: string): Promise<Crawl> {
  */
 async function getNetworkFromUNL(unl: string): Promise<string | undefined> {
   const result = await query('networks')
-    .select('network')
+    .select('id')
     .where('unls', 'like', `%${unl}%`)
-  return result.length > 0 ? result[0].network : undefined
+  return result.length > 0 ? result[0].id : undefined
 }
 
 /**
@@ -130,14 +130,12 @@ async function getNetworkFromPublicKey(
  * @returns The ID of the new network.
  */
 async function addNode(url: string, unl: string | null): Promise<string> {
-  const currentNetworks = await query('networks')
-    .select('network')
-    .orderBy('network')
+  const currentNetworks = await query('networks').select('id').orderBy('id')
   const maxNetwork =
     currentNetworks[currentNetworks.length - networks.length - 1]?.network ?? 0
   const newNetwork = (Number(maxNetwork) + 1).toString()
   const network: Network = {
-    network: newNetwork,
+    id: newNetwork,
     entry: url,
     port: 51235,
     unls: unl ? [unl] : [],

--- a/src/api/routes/v1/get-network.ts
+++ b/src/api/routes/v1/get-network.ts
@@ -11,6 +11,10 @@ const CRAWL_PORTS = [51235, 2459, 30001]
 /**
  * An implementation of `Promise.any`. Returns the first promise to resolve.
  * Ignores errors, unless they all error.
+ * This method is used to improve performance of this API call - since the API
+ * call checks multiple possible ports for the `/crawl` endpoint, it should
+ * return the first one to succeed. The other ones will probably fail, but will
+ * take several seconds to fail.
  * Modified from https://stackoverflow.com/a/57599519.
  *
  * @param promises - The crawl Promises that are waiting.
@@ -78,7 +82,6 @@ async function any(
  *
  * @param host - The host URL to crawl.
  * @returns The crawl data from the node.
- * @throws If none of the possible crawl ports work.
  */
 async function fetchCrawls(host: string): Promise<Crawl> {
   const promises: Array<Promise<Crawl | undefined>> = []
@@ -89,7 +92,8 @@ async function fetchCrawls(host: string): Promise<Crawl> {
 }
 
 /**
- * Checks whether the UNL of the node is recorded in the networks table.
+ * Checks whether the UNL of the node is recorded in the networks table. If so,
+ * then it returns the network associated with the UNL.
  *
  * @param unl - The UNL of the node.
  * @returns Whether the UNL of the node has been seen before.
@@ -102,10 +106,12 @@ async function getNetworkFromUNL(unl: string): Promise<string | undefined> {
 }
 
 /**
- * Checks whether the public key of the node is recorded in the crawls table.
+ * Checks whether the public key of the node is recorded in the crawls table. If
+ * so, then it returns the network associated with the public key.
  *
  * @param publicKey - The public key of the node.
- * @returns Whether the public key of the node has been seen before.
+ * @returns The network associated with the public key of the node. Undefined
+ * if the public key has not been seen by the network.
  */
 async function getNetworkFromPublicKey(
   publicKey: string,

--- a/src/api/routes/v1/get-network.ts
+++ b/src/api/routes/v1/get-network.ts
@@ -13,7 +13,7 @@ const CRAWL_PORTS = [51235, 2459, 30001]
 
 let maxNetwork: number
 
-async function getMaxNetwork(): Promise<void> {
+async function updateMaxNetwork(): Promise<void> {
   const currentNetworks = await query('networks').select('id')
   const currentNetworkNumbers = currentNetworks.reduce(
     (filtered: number[], network: { id: string }) => {
@@ -31,9 +31,9 @@ async function getMaxNetwork(): Promise<void> {
   }
 }
 
-void getMaxNetwork()
+void updateMaxNetwork()
 // double check that the max network is accurate every hour
-setInterval(getMaxNetwork, 60 * 60 * 1000)
+setInterval(updateMaxNetwork, 60 * 60 * 1000)
 
 /**
  * An implementation of `Promise.any`. Returns the first promise to resolve.
@@ -164,7 +164,7 @@ async function getNetworkFromPublicKey(
  * @returns The ID of the new network.
  */
 async function addNode(url: string, unl: string | null): Promise<string> {
-  const newNetwork = (Number(maxNetwork) + 1).toString()
+  const newNetwork = (maxNetwork + 1).toString()
   maxNetwork += 1
 
   const network: Network = {
@@ -191,7 +191,7 @@ async function addNode(url: string, unl: string | null): Promise<string> {
  * @param res - Express response.
  * @returns The Express response.
  */
-export default async function getNetwork(
+export default async function getNetworkOrAdd(
   req: Request,
   res: Response,
 ): Promise<Response> {

--- a/src/api/routes/v1/get-network.ts
+++ b/src/api/routes/v1/get-network.ts
@@ -89,7 +89,7 @@ async function addNode(url: string, unl: string | null): Promise<void> {
  * @param res - Express response.
  * @returns The Express response.
  */
-export default async function addEntry(
+export default async function getNetwork(
   req: Request,
   res: Response,
 ): Promise<Response> {

--- a/src/api/routes/v1/index.ts
+++ b/src/api/routes/v1/index.ts
@@ -1,5 +1,6 @@
 import { Router as createRouter } from 'express'
 
+import addEntry from './add-entry'
 import handleDailyScores from './daily-report'
 import handleHealth from './health'
 import handleValidatorManifest from './manifests'
@@ -11,6 +12,7 @@ const api = createRouter()
 
 api.use('/health', handleHealth)
 api.use('/network/validator_reports', handleDailyScores)
+api.use('/network/add/:entryUrl', addEntry)
 
 api.use('/network/topology/nodes/:network', handleNodes)
 api.use('/network/topology/nodes', handleNodes)

--- a/src/api/routes/v1/index.ts
+++ b/src/api/routes/v1/index.ts
@@ -1,7 +1,7 @@
 import { Router as createRouter } from 'express'
 
 import handleDailyScores from './daily-report'
-import getNetwork from './get-network'
+import getNetworkOrAdd from './get-network'
 import handleHealth from './health'
 import handleValidatorManifest from './manifests'
 import { handleNode, handleNodes, handleTopology } from './nodes'
@@ -12,7 +12,7 @@ const api = createRouter()
 
 api.use('/health', handleHealth)
 api.use('/network/validator_reports', handleDailyScores)
-api.use('/network/get_network/:entryUrl', getNetwork)
+api.use('/network/get_network/:entryUrl', getNetworkOrAdd)
 
 api.use('/network/topology/nodes/:network', handleNodes)
 api.use('/network/topology/nodes', handleNodes)

--- a/src/api/routes/v1/index.ts
+++ b/src/api/routes/v1/index.ts
@@ -1,7 +1,7 @@
 import { Router as createRouter } from 'express'
 
-import addEntry from './add-entry'
 import handleDailyScores from './daily-report'
+import getNetwork from './get-network'
 import handleHealth from './health'
 import handleValidatorManifest from './manifests'
 import { handleNode, handleNodes, handleTopology } from './nodes'
@@ -12,7 +12,7 @@ const api = createRouter()
 
 api.use('/health', handleHealth)
 api.use('/network/validator_reports', handleDailyScores)
-api.use('/network/add/:entryUrl', addEntry)
+api.use('/network/get_network/:entryUrl', getNetwork)
 
 api.use('/network/topology/nodes/:network', handleNodes)
 api.use('/network/topology/nodes', handleNodes)

--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -23,4 +23,6 @@ async function start(): Promise<void> {
   agreement.start()
 }
 
-void start()
+if (typeof require !== 'undefined' && require.main === module) {
+  void start()
+}

--- a/src/crawler/index.ts
+++ b/src/crawler/index.ts
@@ -49,4 +49,6 @@ async function main(): Promise<void> {
   }, LOCATE_INTERVAL)
 }
 
-main().catch((err: Error) => log.error(`${err.message}`))
+if (typeof require !== 'undefined' && require.main === module) {
+  main().catch((err: Error) => log.error(`${err.message}`))
+}


### PR DESCRIPTION
## High Level Overview of Change

This PR creates a new API endpoint, `get_network`, that fetches the network ID of the network that a node is connected to. If it doesn't exist, it creates one, and immediately crawls the network.

The API endpoint takes 300-40ms to load for a rippled node that exists, and 6ish seconds for an endpoint that is not a rippled node (since it waits for the call to `/crawl` to error).

### Context of Change

This is necessary for sidechains - if the Explorer wants to visit a new sidechain that it hasn't been to before, it needs to add it to the VHS. And this must happen programatically.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Tested several scenarios by hand.
