### PR TITLE
Add release version to validators

### DIFF
--- a/src/api/routes/v1/validator.ts
+++ b/src/api/routes/v1/validator.ts
@@ -19,7 +19,7 @@ interface ValidatorResponse {
   domain: string
   chain: string
   current_index: number
-  server_version: string | null
+  server_version?: string
   agreement_1h: {
     missed: number
     total: number
@@ -69,7 +69,7 @@ interface dbResponse {
   current_index: string
   domain: string
   chain: string
-  server_version: string | null
+  server_version?: string
   master_key?: string
   signing_key: string
   revoked?: boolean

--- a/src/api/routes/v1/validator.ts
+++ b/src/api/routes/v1/validator.ts
@@ -19,6 +19,7 @@ interface ValidatorResponse {
   domain: string
   chain: string
   current_index: number
+  server_version: string | null
   agreement_1h: {
     missed: number
     total: number
@@ -68,6 +69,7 @@ interface dbResponse {
   current_index: string
   domain: string
   chain: string
+  server_version: string | null
   master_key?: string
   signing_key: string
   revoked?: boolean
@@ -94,6 +96,7 @@ async function getValidators(): Promise<ValidatorResponse[]> {
       'current_index',
       'domain',
       'chain',
+      'server_version',
       'master_key',
       'signing_key',
       'master_key',
@@ -170,6 +173,7 @@ function formatResponse(resp: dbResponse): ValidatorResponse {
     master_key: resp.master_key,
     domain: resp.domain,
     chain: resp.chain,
+    server_version: resp.server_version,
     current_index: Number(resp.current_index),
     agreement_1h: hour1_score,
     agreement_24h: hour24_score,
@@ -199,6 +203,7 @@ async function findInDatabase(
       'current_index',
       'domain',
       'chain',
+      'server_version',
       'master_key',
       'signing_key',
       'master_key',

--- a/src/connection-manager/agreement.ts
+++ b/src/connection-manager/agreement.ts
@@ -114,7 +114,7 @@ async function updateDailyAgreement(
  * @param ledger_index - Index of current ledger.
  * @returns Boolean.
  */
-function preceedFlagLedger(ledger_index: string): boolean {
+function isPreceedingFlagLedger(ledger_index: string): boolean {
   return parseInt(ledger_index, 10) % 256 === 255
 }
 
@@ -186,7 +186,7 @@ class Agreement {
       hashes.set(validation.ledger_hash, Date.now())
       this.validationsByPublicKey.set(signing_key, hashes)
       const server_version =
-        preceedFlagLedger(validation.ledger_index) &&
+        isPreceedingFlagLedger(validation.ledger_index) &&
         decodeServerVersion(validation.server_version)
       const validator: Validator = {
         master_key: validation.master_key,

--- a/src/connection-manager/agreement.ts
+++ b/src/connection-manager/agreement.ts
@@ -1,3 +1,7 @@
+/* eslint-disable no-negated-condition -- Negation is used for release version decoding. */
+/* eslint-disable no-nested-ternary -- Nested ternary is used for release version decoding. */
+/* eslint-disable no-bitwise -- Bitwise operation is used for release version decoding. */
+
 import {
   getAgreementScores,
   saveHourlyAgreement,

--- a/src/connection-manager/agreement.ts
+++ b/src/connection-manager/agreement.ts
@@ -105,7 +105,7 @@ async function updateDailyAgreement(
 }
 
 /**
- * Updates agreement for a validator.
+ * Detect the ledger before a flagged ledger, which will contain server version information.
  *
  * @param ledger_index - Index of current ledger.
  * @returns Boolean.

--- a/src/connection-manager/agreement.ts
+++ b/src/connection-manager/agreement.ts
@@ -182,8 +182,6 @@ class Agreement {
 
     const hashes = this.validationsByPublicKey.get(signing_key) ?? new Map()
 
-    console.log(validation)
-
     if (!hashes.has(validation.ledger_hash)) {
       hashes.set(validation.ledger_hash, Date.now())
       this.validationsByPublicKey.set(signing_key, hashes)

--- a/src/shared/database/agreement.ts
+++ b/src/shared/database/agreement.ts
@@ -225,3 +225,73 @@ export async function update30DayValidatorAgreement(
       )
   }
 }
+
+/**
+ * Classify server version type.
+ *
+ * @param beta - Extracted 8-bit beta identifier.
+ * @throws InvalidVersionException.
+ * @returns Release version type (basic, beta, rc, etc.).
+ */
+function extractServerVersionType(beta: number): string | null {
+  // eslint-disable-next-line no-bitwise -- Use bit shifts to extract the first 2 bits that contain release version type.
+  const typeBits = beta >> 6
+  if (typeBits === 0) {
+    return null
+  }
+
+  const isBeta = typeBits === 1
+  const isRC = typeBits === 2
+  const isRelease = typeBits === 3
+
+  const prefix = isRelease ? '' : '-'
+  // eslint-disable-next-line no-nested-ternary -- Nested tenary is used to determine release type based on 2 conditions.
+  const releaseType = isBeta ? 'b' : isRC ? 'rc' : ''
+
+  // eslint-disable-next-line no-bitwise -- Bit mask is used to extract release number from 8-bit beta.
+  const releaseNum = isRelease ? '' : beta & 0x3f
+
+  return `${prefix}${releaseType}${releaseNum}`
+}
+
+/**
+ * Decode server software version.
+ *
+ * @param server_version - Software server version in 64 bits integer.
+ * @throws InvalidVersionException.
+ * @returns Decoded server version in standard format.
+ */
+export function decodeServerVersion(server_version?: string): string | null {
+  if (!server_version) {
+    return null
+  }
+
+  const num = BigInt(server_version)
+
+  const buf = Buffer.alloc(8)
+
+  buf.writeBigInt64BE(num)
+
+  if (
+    buf.length !== 8 ||
+    buf[0] !== 0x18 ||
+    buf[1] !== 0x3b ||
+    buf[7] !== 0 ||
+    buf[6] !== 0
+  ) {
+    return null
+  }
+
+  const major = buf[2]
+  const minor = buf[3]
+  const patch = buf[4]
+  const beta = buf[5]
+
+  const betaString = extractServerVersionType(beta)
+
+  if (betaString === null) {
+    return null
+  }
+
+  return `${major}.${minor}.${patch}${betaString}`
+}

--- a/src/shared/database/agreement.ts
+++ b/src/shared/database/agreement.ts
@@ -231,7 +231,7 @@ export async function update30DayValidatorAgreement(
  *
  * @param beta - Extracted 8-bit beta identifier.
  * @throws InvalidVersionException.
- * @returns Empty if a release version, -b<beta version> if a beta version, -rc<release candidate version> if a release candidate.
+ * @returns Empty if a release version, -b(beta version) if a beta version, -rc(release candidate version) if a release candidate.
  */
 function extractServerVersionType(beta: number): string | null {
   // eslint-disable-next-line no-bitwise -- Use bit shifts to extract the first 2 bits that contain release version type.

--- a/src/shared/database/agreement.ts
+++ b/src/shared/database/agreement.ts
@@ -227,11 +227,11 @@ export async function update30DayValidatorAgreement(
 }
 
 /**
- * Classify server version type.
+ * Extracts the server version type from the beta version byte.
  *
  * @param beta - Extracted 8-bit beta identifier.
  * @throws InvalidVersionException.
- * @returns Release version type (basic, beta, rc, etc.).
+ * @returns Empty if a release version, -b<beta version> if a beta version, -rc<release candidate version> if a release candidate.
  */
 function extractServerVersionType(beta: number): string | null {
   // eslint-disable-next-line no-bitwise -- Use bit shifts to extract the first 2 bits that contain release version type.

--- a/src/shared/database/index.ts
+++ b/src/shared/database/index.ts
@@ -16,6 +16,7 @@ import {
   update1HourValidatorAgreement,
   update24HourValidatorAgreement,
   update30DayValidatorAgreement,
+  decodeServerVersion,
 } from './agreement'
 import { Network } from './networks'
 import setupTables from './setup'
@@ -264,4 +265,5 @@ export {
   update1HourValidatorAgreement,
   update24HourValidatorAgreement,
   update30DayValidatorAgreement,
+  decodeServerVersion,
 }

--- a/src/shared/database/setup.ts
+++ b/src/shared/database/setup.ts
@@ -129,7 +129,7 @@ async function setupValidatorsTable(): Promise<void> {
     })
   }
   if (!(await db().schema.hasColumn('validators', 'server_version'))) {
-    await db().schema.table('validators', (table) => {
+    await db().schema.alterTable('validators', (table) => {
       table.string('server_version').after('domain_verified')
     })
   }

--- a/src/shared/database/setup.ts
+++ b/src/shared/database/setup.ts
@@ -128,6 +128,11 @@ async function setupValidatorsTable(): Promise<void> {
       table.json('agreement_30day')
     })
   }
+  if (!(await db().schema.hasColumn('validators', 'server_version'))) {
+    await db().schema.table('validators', (table) => {
+      table.string('server_version').after('domain_verified')
+    })
+  }
 }
 
 async function setupHourlyAgreementTable(): Promise<void> {

--- a/src/shared/database/setup.ts
+++ b/src/shared/database/setup.ts
@@ -121,6 +121,7 @@ async function setupValidatorsTable(): Promise<void> {
       table.string('unl')
       table.string('domain')
       table.boolean('domain_verified')
+      table.string('version')
       table.dateTime('last_ledger_time')
       table.json('agreement_1hour')
       table.json('agreement_24hour')

--- a/src/shared/database/setup.ts
+++ b/src/shared/database/setup.ts
@@ -121,7 +121,7 @@ async function setupValidatorsTable(): Promise<void> {
       table.string('unl')
       table.string('domain')
       table.boolean('domain_verified')
-      table.string('version')
+      table.string('server_version')
       table.dateTime('last_ledger_time')
       table.json('agreement_1hour')
       table.json('agreement_24hour')

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -86,6 +86,7 @@ interface Validator {
   current_index: number
   partial: boolean
   last_ledger_time: Date
+  server_version?: string
 }
 
 interface DatabaseValidator extends Validator {
@@ -101,7 +102,6 @@ interface DatabaseValidator extends Validator {
   agreement_24hour: Agreement
   agreement_30day: Agreement
   updated: string
-  server_version: string
 }
 
 interface DatabaseNetwork {

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -101,7 +101,7 @@ interface DatabaseValidator extends Validator {
   agreement_24hour: Agreement
   agreement_30day: Agreement
   updated: string
-  version: string
+  server_version: string
 }
 
 interface DatabaseNetwork {

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -69,6 +69,7 @@ interface ValidationRaw {
   signing_time: number
   type: string
   validation_public_key: string
+  server_version?: string
   // The validation_public_key is the same as the signing_key in StreamManifest
 }
 
@@ -100,6 +101,7 @@ interface DatabaseValidator extends Validator {
   agreement_24hour: Agreement
   agreement_30day: Agreement
   updated: string
+  version: string
 }
 
 interface DatabaseNetwork {

--- a/test/chains/agreement.test.ts
+++ b/test/chains/agreement.test.ts
@@ -1,5 +1,10 @@
 import agreement from '../../src/connection-manager/agreement'
-import { destroy, query, setupTables } from '../../src/shared/database'
+import {
+  decodeServerVersion,
+  destroy,
+  query,
+  setupTables,
+} from '../../src/shared/database'
 
 import validations from './fixtures/all-validations.json'
 
@@ -51,5 +56,31 @@ describe('Agreement', () => {
     expect(daily_master_keys).toContain('VALIDATOR1MASTER')
     expect(daily_master_keys).toContain('VALIDATOR2MASTER')
     expect(daily_master_keys).toContain('VALIDATOR3MASTER')
+  })
+
+  test('Correctly decode server version for validators', () => {
+    const correctBasicVersion = decodeServerVersion('1745990418748669952')
+    const correctRCVersion = decodeServerVersion('1745990418744934400')
+    const correctBetaVersion = decodeServerVersion('1745990418740740096')
+    expect(correctBasicVersion).toBe('1.9.2')
+    expect(correctRCVersion).toBe('1.9.2-rc7')
+    expect(correctBetaVersion).toBe('1.9.2-b7')
+  })
+
+  test('Returns null if server version implementation identifier is invalid', () => {
+    const incorrectVersionFirst8B = decodeServerVersion('1673932824710742016')
+    const incorrectVersionNext8B = decodeServerVersion('1735857319587086336')
+    expect(incorrectVersionFirst8B).toBe(null)
+    expect(incorrectVersionNext8B).toBe(null)
+  })
+
+  test('Returns null if release type bits is not either 10, 01 or 11', () => {
+    const incorrectVersionType = decodeServerVersion('1745990418736087040')
+    expect(incorrectVersionType).toBe(null)
+  })
+
+  test('Returns null if server version last 16 bits are not 0', () => {
+    const incorrectVersionLast16B = decodeServerVersion('1745990418748670208')
+    expect(incorrectVersionLast16B).toBe(null)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

Track validator server version by analyzing validation. 

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->
rippled version 1.8+ includes rippled version numbers in validation messages. Track these versions in the VHS API.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

Validators relation did not have server version before. Changes were made to include this new field.

Example API call after the change:
`/network/validator/nHUvzia57LRXr9zqnYpyFUFeKvis2tqn4DkXBVGSppt5M4nNq43C`

Example result:
<code>{
    "validation_public_key": "nHUvzia57LRXr9zqnYpyFUFeKvis2tqn4DkXBVGSppt5M4nNq43C",
    "signing_key": "n9KY4JZY11ndNbg55dThnoQdU9dii5q3egzoESVXw4Z7hu3maCba",
    "master_key": "nHUvzia57LRXr9zqnYpyFUFeKvis2tqn4DkXBVGSppt5M4nNq43C",
    "domain": "digifin.uk",
    "chain": "main",
    <b>"server_version": "1.9.2"</b>,
    "current_index": 73739542,
    "agreement_1h": {
        "missed": 1,
        "total": 930,
        "score": "0.99892",
        "incomplete": true
    },
    "agreement_24h": {
        "missed": 1,
        "total": 930,
        "score": "0.99892",
        "incomplete": true
    },
    "agreement_30day": {
        "missed": 1,
        "total": 930,
        "score": "0.99892",
        "incomplete": true
    },
    "partial": false,
    "unl": "vl.ripple.com",
    "revoked": false,
    "result": "success"
}</code>

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

- Server version is inserted for validators table.
- Correct version is updated for the server_version column.
- Correct release (basic, rc, beta, etc.)
- server_version column will not be updated if there's no server version in the ledger.

<!--
## Future Tasks
For future tasks related to PR.
-->
