### PR TITLE
fix: UNLs does not get updated when a network has empty UNLs

### DIFF
--- a/src/connection-manager/manifests.ts
+++ b/src/connection-manager/manifests.ts
@@ -85,7 +85,10 @@ export async function handleManifest(
 export async function updateUNLManifests(): Promise<void> {
   try {
     log.info('Fetching UNL...')
-    const unl: UNLBlob = await fetchValidatorList(await getFirstUNL('main'))
+    const unl: UNLBlob = await fetchValidatorList(
+      await getFirstUNL('main'),
+      'main',
+    )
     const promises: Array<Promise<void>> = []
 
     unl.validators.forEach((validator: UNLValidator) => {

--- a/src/connection-manager/manifests.ts
+++ b/src/connection-manager/manifests.ts
@@ -85,10 +85,7 @@ export async function handleManifest(
 export async function updateUNLManifests(): Promise<void> {
   try {
     log.info('Fetching UNL...')
-    const unl: UNLBlob = await fetchValidatorList(
-      await getFirstUNL('main'),
-      'main',
-    )
+    const unl: UNLBlob = await fetchValidatorList(await getFirstUNL('main'))
     const promises: Array<Promise<void>> = []
 
     unl.validators.forEach((validator: UNLValidator) => {

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -27,7 +27,10 @@ export async function fetchValidatorList(
     const blobParsed: UNLBlob = JSON.parse(buf.toString('ascii'))
     return blobParsed
   } catch (err: unknown) {
-    log.error(`Error fetching validator List for network ${networkId}`, err)
+    log.error(
+      `Error fetching validator List for network ${networkId} and url ${url}`,
+      err,
+    )
     return Promise.reject()
   }
 }
@@ -123,13 +126,15 @@ export async function getLists(): Promise<Record<string, Set<string>>> {
   const promises: Array<Promise<void>> = []
   const networks = await getNetworks()
   networks.forEach(async (network) => {
-    promises.push(
-      fetchValidatorList(network.unls[0], network.id).then((blob) => {
-        Object.assign(lists, {
-          [network.id]: blobToValidators(blob),
-        })
-      }),
-    )
+    if (network.unls[0]) {
+      promises.push(
+        fetchValidatorList(network.unls[0], network.id).then((blob) => {
+          Object.assign(lists, {
+            [network.id]: blobToValidators(blob),
+          })
+        }),
+      )
+    }
   })
   await Promise.all(
     // The error has already been logged in fetchValidatorList

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -127,7 +127,9 @@ export async function getLists(): Promise<Record<string, Set<string>>> {
       }),
     )
   })
-  await Promise.all(promises)
+  await Promise.all(
+    promises.map(async (promise) => promise.catch(async (err) => err)),
+  )
   return lists
 }
 


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->
`updateUNLs` is failing for all validators on staging and production since there's a new network added with empty UNLs. Prevent this from happening by fixing `Promise.all` in `fetchValidatorList` to continue even when a promise raises an error.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

Ensure `updateUNLs` run successfully in staging and validator with pubkey `nHUon2tpyJEHHYGmxqeGu37cvPYHzrMtUNQFVdCgGNvEkjmCpTqK` is removed from vl.ripple.com. 
