### PR TITLE
fix: use most updated network for validators

### DIFF
--- a/src/connection-manager/agreement.ts
+++ b/src/connection-manager/agreement.ts
@@ -9,7 +9,6 @@ import {
   purgeHourlyAgreementScores,
   signingToMaster,
   decodeServerVersion,
-  query,
 } from '../shared/database'
 import {
   AgreementScore,
@@ -198,16 +197,8 @@ class Agreement {
         last_ledger_time: new Date(),
       }
 
-      // Comma-separated for testing purposes, will be removed
-      const dbNetworks = await query('validators')
-        .select('networks')
-        .where({ signing_key })
-        .catch((err) => log.error('Error retrieving networks', err))
-
-      const arr = dbNetworks[0]?.networks?.split(',') || []
       if (validation.networks) {
-        arr.push(validation.networks)
-        validator.networks = Array.from(new Set(arr)).join()
+        validator.networks = validation.networks
       }
 
       if (server_version) {


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

`Validators` table is updating networks with comma-separated. This change will keep only the most updated one.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
