### PR TITLE
fix: fix hooks testnet crawl output

### DIFF
--- a/src/api/routes/v1/get-network.ts
+++ b/src/api/routes/v1/get-network.ts
@@ -9,7 +9,7 @@ import logger from '../../../shared/utils/logger'
 
 const log = logger({ name: 'api-get-network' })
 
-const CRAWL_PORTS = [51235, 2459, 30001]
+const CRAWL_PORTS = [51235, 2459, 30001, 443]
 
 let maxNetwork: number
 

--- a/src/shared/database/index.ts
+++ b/src/shared/database/index.ts
@@ -84,7 +84,7 @@ export async function saveNodeWsUrl(
       })
       .catch((err: Error) => log.error(err.message))
   } else {
-    log.warn('Invalid websocket url')
+    log.warn(`Invalid websocket url: ${url}`)
   }
 }
 

--- a/src/shared/database/networks.ts
+++ b/src/shared/database/networks.ts
@@ -48,8 +48,8 @@ const networks: Network[] = [
   },
   {
     id: 'hooks-test',
-    entry: '88.99.3.241',
-    port: 21338,
+    entry: 'hooks-testnet-v3.xrpl-labs.com',
+    port: 443,
     unls: ['vl3.beta.bithomp.com'],
   },
 ]


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes the hooks testnet crawling and subscribing, by adding the right node to crawl and supporting that endpoint.

### Context of Change

The Networks tab on the Explorer wasn't working properly for the hooks testnet.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Works locally. Will test in staging.