### PR TITLE
fix: decode manifests from UNLs for all networks

### DIFF
--- a/src/connection-manager/manifests.ts
+++ b/src/connection-manager/manifests.ts
@@ -83,9 +83,23 @@ export async function handleManifest(
  * @returns A promise that resolves to void once all UNL validators are saved.
  */
 export async function updateUNLManifests(): Promise<void> {
+  const networks = (await getNetworks()).map((network) => network.id)
+  const promises = networks.map(async (network) =>
+    updateUNLManifestNetwork(network),
+  )
+  await Promise.all(promises)
+}
+
+/**
+ * Saves manifests from the UNL.
+ *
+ * @param network - The network to update.
+ * @returns A promise that resolves to void once all UNL validators are saved.
+ */
+async function updateUNLManifestNetwork(network: string): Promise<void> {
   try {
     log.info('Fetching UNL...')
-    const unl: UNLBlob = await fetchValidatorList(await getFirstUNL('main'))
+    const unl: UNLBlob = await fetchValidatorList(await getFirstUNL(network))
     const promises: Array<Promise<void>> = []
 
     unl.validators.forEach((validator: UNLValidator) => {
@@ -152,7 +166,7 @@ async function updateValidatorDomainsFromManifests(): Promise<void> {
 }
 
 /**
- * Update the unl column if the validator is included in a validator list (main, testnet, or devnet).
+ * Update the unl column if the validator is included in a validator list for a network.
  * The unl column contains the domain where the validator list is served.
  *
  * @returns A promise that resolves to void once unl column is updated for all applicable validators.

--- a/test/manifests/manifests.test.ts
+++ b/test/manifests/manifests.test.ts
@@ -73,7 +73,9 @@ describe('manifest ingest', () => {
   })
 
   test('updateUnlManifests', async () => {
-    nock(`http://${VALIDATOR_URL}`).get('/').reply(200, unl1)
+    networks.forEach((network) => {
+      nock(`http://${network.unls[0]}`).get('/').reply(200, unl1)
+    })
     await updateUNLManifests()
     const saved_manifest = await query('manifests').select('*')
 


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

The hooks testnet doesn't automatically go through the manifest, so we need to do it by hand. We may as well do it for all the networks, instead of just mainnet.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Works locally.
