### PR TITLE
chore: run tests on Node 18.x and 20.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,18 +2,17 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     services:
@@ -35,27 +34,27 @@ jobs:
           - 5432:5432
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-      # TODO: remove the --legacy-peer-deps here
-    - run: npm ci --legacy-peer-deps
-    - run: npm run lint:ci
-    - run: npm run build
-    - run: npm test
-      env:
-        # The hostname used to communicate with the PostgreSQL service container
-        POSTGRES_HOST: postgres
-        # The default PostgreSQL port
-        POSTGRES_PORT: 5432
-        # Database connection info
-        DB_HOST: 'localhost'
-        DB_USER: 'postgres'
-        DB_DATABASE: 'postgres'
-        DB_PASSWORD: 'postgres'
-        # Rippled Server with access to manifest command
-        RIPPLED_RPC_ADMIN: 'https://xrpl.ws/'
-        # (Placeholder) Mainnet entry point for crawler (without https://).
-        MAINNET_P2P_ENTRY: 'test.example.com'
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+        # TODO: remove the --legacy-peer-deps here
+      - run: npm ci --legacy-peer-deps
+      - run: npm run lint:ci
+      - run: npm run build
+      - run: npm test
+        env:
+          # The hostname used to communicate with the PostgreSQL service container
+          POSTGRES_HOST: postgres
+          # The default PostgreSQL port
+          POSTGRES_PORT: 5432
+          # Database connection info
+          DB_HOST: 'localhost'
+          DB_USER: 'postgres'
+          DB_DATABASE: 'postgres'
+          DB_PASSWORD: 'postgres'
+          # Rippled Server with access to manifest command
+          RIPPLED_RPC_ADMIN: 'https://xrpl.ws/'
+          # (Placeholder) Mainnet entry point for crawler (without https://).
+          MAINNET_P2P_ENTRY: 'test.example.com'


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

With Node 14.x being deprecated, I wanted to make sure the VHS ran on newer versions of Node

### Type of Change

- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Test Plan

CI passes.