### PR TITLE
fix: update chain when a network resets

### DIFF
--- a/src/connection-manager/agreement.ts
+++ b/src/connection-manager/agreement.ts
@@ -146,7 +146,7 @@ class Agreement {
     log.info('Calculating agreement scores')
     const promises = []
 
-    const agreementChains = chains.calculateChainsFromLedgers()
+    const agreementChains = await chains.calculateChainsFromLedgers()
 
     for (const chain of agreementChains) {
       const ledger_hashes = chain.ledgers

--- a/test/chains/chains.test.ts
+++ b/test/chains/chains.test.ts
@@ -30,7 +30,7 @@ describe('Creates chains', () => {
     const constructed: Array<{
       ledgers: Set<string>
       validators: Set<string>
-    }> = chains.calculateChainsFromLedgers()
+    }> = await chains.calculateChainsFromLedgers()
 
     expect(constructed[0].ledgers).toContain('LEDGER1')
     expect(constructed[0].ledgers).toContain('LEDGER2')
@@ -47,7 +47,7 @@ describe('Creates chains', () => {
     const constructed: Array<{
       ledgers: Set<string>
       validators: Set<string>
-    }> = chains.calculateChainsFromLedgers()
+    }> = await chains.calculateChainsFromLedgers()
 
     expect(constructed[0].ledgers).toEqual(new Set())
 

--- a/test/chains/fixtures/reset-validations.json
+++ b/test/chains/fixtures/reset-validations.json
@@ -1,0 +1,101 @@
+[
+  {
+    "flags": 2147483649,
+    "full": true,
+    "ledger_hash": "LEDGER1000",
+    "ledger_index": "1000",
+    "master_key": "VALIDATOR1MASTER",
+    "signature": "30440220342DFBFBA1ACF758805A1CD5FF0C4E39F0A2800D0400F430A22BEBDB2B9E327A02204776C0E90942FB9CACDB763535AFAADBA1506E94CD92A605296153D8362D01E3",
+    "signing_time": 669928656,
+    "type": "validationReceived",
+    "validation_public_key": "VALIDATOR1"
+  },
+  {
+    "flags": 2147483649,
+    "full": true,
+    "ledger_hash": "LEDGER1000",
+    "ledger_index": "1000",
+    "master_key": "VALIDATOR2MASTER",
+    "signature": "30440220342DFBFBA1ACF758805A1CD5FF0C4E39F0A2800D0400F430A22BEBDB2B9E327A02204776C0E90942FB9CACDB763535AFAADBA1506E94CD92A605296153D8362D01E3",
+    "signing_time": 669928656,
+    "type": "validationReceived",
+    "validation_public_key": "VALIDATOR2"
+  },
+  {
+    "flags": 2147483649,
+    "full": true,
+    "ledger_hash": "LEDGER1000",
+    "ledger_index": "1000",
+    "master_key": "VALIDATOR3MASTER",
+    "signature": "30440220342DFBFBA1ACF758805A1CD5FF0C4E39F0A2800D0400F430A22BEBDB2B9E327A02204776C0E90942FB9CACDB763535AFAADBA1506E94CD92A605296153D8362D01E3",
+    "signing_time": 669928656,
+    "type": "validationReceived",
+    "validation_public_key": "VALIDATOR3"
+  },
+  {
+    "flags": 2147483649,
+    "full": true,
+    "ledger_hash": "LEDGER1001",
+    "ledger_index": "1001",
+    "master_key": "VALIDATOR1MASTER",
+    "signature": "30440220342DFBFBA1ACF758805A1CD5FF0C4E39F0A2800D0400F430A22BEBDB2B9E327A02204776C0E90942FB9CACDB763535AFAADBA1506E94CD92A605296153D8362D01E3",
+    "signing_time": 669928656,
+    "type": "validationReceived",
+    "validation_public_key": "VALIDATOR1"
+  },
+  {
+    "flags": 2147483649,
+    "full": true,
+    "ledger_hash": "LEDGER1001",
+    "ledger_index": "1001",
+    "master_key": "VALIDATOR2MASTER",
+    "signature": "30440220342DFBFBA1ACF758805A1CD5FF0C4E39F0A2800D0400F430A22BEBDB2B9E327A02204776C0E90942FB9CACDB763535AFAADBA1506E94CD92A605296153D8362D01E3",
+    "signing_time": 669928656,
+    "type": "validationReceived",
+    "validation_public_key": "VALIDATOR2"
+  },
+  {
+    "flags": 2147483649,
+    "full": true,
+    "ledger_hash": "LEDGER1001",
+    "ledger_index": "1001",
+    "master_key": "VALIDATOR3MASTER",
+    "signature": "30440220342DFBFBA1ACF758805A1CD5FF0C4E39F0A2800D0400F430A22BEBDB2B9E327A02204776C0E90942FB9CACDB763535AFAADBA1506E94CD92A605296153D8362D01E3",
+    "signing_time": 669928656,
+    "type": "validationReceived",
+    "validation_public_key": "VALIDATOR3"
+  },
+  {
+    "flags": 2147483649,
+    "full": true,
+    "ledger_hash": "LEDGER1",
+    "ledger_index": "1",
+    "master_key": "VALIDATOR1MASTER",
+    "signature": "30440220342DFBFBA1ACF758805A1CD5FF0C4E39F0A2800D0400F430A22BEBDB2B9E327A02204776C0E90942FB9CACDB763535AFAADBA1506E94CD92A605296153D8362D01E3",
+    "signing_time": 669928656,
+    "type": "validationReceived",
+    "validation_public_key": "VALIDATOR1"
+  },
+  {
+    "flags": 2147483649,
+    "full": true,
+    "ledger_hash": "LEDGER1",
+    "ledger_index": "1",
+    "master_key": "VALIDATOR2MASTER",
+    "signature": "30440220342DFBFBA1ACF758805A1CD5FF0C4E39F0A2800D0400F430A22BEBDB2B9E327A02204776C0E90942FB9CACDB763535AFAADBA1506E94CD92A605296153D8362D01E3",
+    "signing_time": 669928656,
+    "type": "validationReceived",
+    "validation_public_key": "VALIDATOR2"
+  },
+  {
+    "flags": 2147483649,
+    "full": true,
+    "ledger_hash": "LEDGER1",
+    "ledger_index": "1",
+    "master_key": "VALIDATOR3MASTER",
+    "signature": "30440220342DFBFBA1ACF758805A1CD5FF0C4E39F0A2800D0400F430A22BEBDB2B9E327A02204776C0E90942FB9CACDB763535AFAADBA1506E94CD92A605296153D8362D01E3",
+    "signing_time": 669928656,
+    "type": "validationReceived",
+    "validation_public_key": "VALIDATOR3"
+  }
+]

--- a/test/chains/network-reset.test.ts
+++ b/test/chains/network-reset.test.ts
@@ -1,0 +1,58 @@
+import chains from '../../src/connection-manager/chains'
+import { destroy, setupTables } from '../../src/shared/database'
+
+import validationsAtReset from './fixtures/reset-validations.json'
+
+jest.useFakeTimers()
+
+describe('Chains on reset', () => {
+  beforeAll(async () => {
+    await setupTables()
+  })
+
+  afterAll(async () => {
+    await destroy()
+  })
+
+  test('Chain at reset before purged', async () => {
+    for (const validation of validationsAtReset.slice(0, 6)) {
+      chains.updateLedgers(validation)
+    }
+
+    let time = Date.now() + 11000
+    Date.now = (): number => time
+
+    const before: Array<{
+      ledgers: Set<string>
+      validators: Set<string>
+    }> = await chains.calculateChainsFromLedgers()
+
+    expect(before[0].ledgers).toContain('LEDGER1000')
+    expect(before[0].ledgers).toContain('LEDGER1001')
+
+    expect(before[0].validators).toContain('VALIDATOR1')
+    expect(before[0].validators).toContain('VALIDATOR2')
+    expect(before[0].validators).toContain('VALIDATOR3')
+
+    // Reset the network
+    for (const validation of validationsAtReset.slice(6)) {
+      chains.updateLedgers(validation)
+    }
+
+    time = Date.now() + 11000
+    Date.now = (): number => time
+
+    const after: Array<{
+      ledgers: Set<string>
+      validators: Set<string>
+    }> = await chains.calculateChainsFromLedgers()
+
+    expect(after.length).toEqual(1)
+    expect(after[0].ledgers.size).toEqual(1)
+    expect(after[0].ledgers).toContain('LEDGER1')
+
+    expect(before[0].validators).toContain('VALIDATOR1')
+    expect(before[0].validators).toContain('VALIDATOR2')
+    expect(before[0].validators).toContain('VALIDATOR3')
+  })
+})

--- a/test/chains/single-validations.test.ts
+++ b/test/chains/single-validations.test.ts
@@ -30,7 +30,7 @@ describe('Single Validations', () => {
     const constructed: Array<{
       ledgers: Set<string>
       validators: Set<string>
-    }> = chains.calculateChainsFromLedgers()
+    }> = await chains.calculateChainsFromLedgers()
 
     expect(constructed).toEqual([])
   })


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

When a network resets, there will be no major issue with the existing APIs (except amendments for that network has to be manually updated, which would be in a separate ticket after the amendments PR has been merged).

One minor issue with the existing process is that, if after the reset, validations come in and the chain has not been purged (purging happens every hour if the chain has not been updated for an hour, so there is still a chance that this is the case), then new ledgers would not be added into the chain for agreement calculation, hence, some agreement scores will be missed until the chain has been purged and a new chain is added. Hence, agreement score might still be calculated based on data before reset only.
(Existing code for reference:
```
   if (chainWithThisValidator !== undefined) {
      const skipped = ledger.ledger_index - chainWithThisValidator.current
      log.warn('Possibly skipped ${skipped} ledgers')
      // all new validations after reset will not satisfy this condition and will not be added
      // until the chain is purged due to inactivity.
      if (skipped > 1 && skipped < 20) {
        chainWithThisValidator.incomplete = true
        addLedgerToChain(ledger, chainWithThisValidator)
      }
    }

    if (chainWithThisValidator !== undefined || chainWithLedger !== undefined) {
      return
    }
```
)

The fix for this would be:
- If the chain has not been purged, reset the chain if see a validation from overlapping validator that has ledger_index less than 20 compared to the current index the chain has seen from previous agreement calculation (one hour ago). Delete all agreement scores of all validators in the chain to recalculate.
- If the chain has been purged, when validations come in, a new chain will be created. Clears all agreement scores for all validators belong to this chain before reset.


### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->
Tests passed. The APIs run normally on staging for a few days.
