### PR TITLE
feat: log when a validator misses a validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ node_modules
 
 # Mac-specific
 .DS_Store
+
+# IDEA based IDEs
+.idea
+*.iml

--- a/src/connection-manager/agreement.ts
+++ b/src/connection-manager/agreement.ts
@@ -275,7 +275,7 @@ class Agreement {
       const validationHash = validations.get(missedLedger[0])?.ledger_hash
       log.warn(
         `Chain ${chain.id} had a validator (${
-          validator_keys.signing_key
+          validator_keys.master_key ?? validator_keys.signing_key
         }) miss a ledger (${missedLedger[0]}) due to ${
           validationHash
             ? `a mismatched hash of ${validationHash}`

--- a/src/connection-manager/chains.ts
+++ b/src/connection-manager/chains.ts
@@ -24,7 +24,7 @@ function sortChainLength(chain1: Chain, chain2: Chain): number {
  * @param chain - Chain to update.
  */
 function addLedgerToChain(ledger: Ledger, chain: Chain): void {
-  chain.ledgers.add(ledger.ledger_hash)
+  chain.ledgers.set(ledger.ledger_hash, ledger.ledger_index)
   for (const validator of ledger.validations) {
     chain.validators.add(validator)
   }
@@ -169,7 +169,7 @@ class Chains {
   private addNewChain(ledger: Ledger): void {
     const current = ledger.ledger_index
     const validators = ledger.validations
-    const ledgerSet = new Set([ledger.ledger_hash])
+    const ledgerSet = new Map().set(ledger.ledger_hash, ledger.ledger_index)
 
     const chain: Chain = {
       id: this.getNextChainID(),

--- a/src/connection-manager/wsHandling.ts
+++ b/src/connection-manager/wsHandling.ts
@@ -12,6 +12,7 @@ import {
   AmendmentStatus,
   DatabaseValidator,
   FeeVote,
+  LedgerIndex,
   LedgerResponseCorrected,
   StreamLedger,
   StreamManifest,
@@ -62,7 +63,7 @@ export function getAmendmentLedgerEntry(ws: WebSocket): void {
  * @param ws - A WebSocket object.
  * @param ledger_index -- The index of the ledger.
  */
-function getEnableAmendmentLedger(ws: WebSocket, ledger_index: number): void {
+function getEnableAmendmentLedger(ws: WebSocket, ledger_index: string): void {
   ws.send(
     JSON.stringify({
       command: 'ledger',
@@ -94,8 +95,8 @@ function getEnableAmendmentTx(ws: WebSocket, transaction: string): void {
  * @param ledger_index - The index of the ledger.
  * @returns Boolean.
  */
-function isFlagLedgerPlusOne(ledger_index: number): boolean {
-  if (ledger_index % 256 === 1) {
+function isFlagLedgerPlusOne(ledger_index: LedgerIndex): boolean {
+  if (Number(ledger_index) % 256 === 1) {
     return true
   }
   return false

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -8,19 +8,22 @@ import {
 import { Ledger as LedgerXRPL } from 'xrpl/dist/npm/models/ledger'
 import { Manifest, StreamManifest } from 'xrpl-validator-domains'
 
+type LedgerIndex = string
+type LedgerHash = string
+
 interface Chain {
   id: string
   current: number
   first: number
   validators: Set<string>
   updated: number
-  ledgers: Set<string>
+  ledgers: Map<LedgerHash, LedgerIndex>
   incomplete: boolean
 }
 
 interface Ledger {
-  ledger_hash: string
-  ledger_index: number
+  ledger_hash: LedgerHash
+  ledger_index: LedgerIndex
   validations: Set<string>
   first_seen: number
 }
@@ -28,8 +31,8 @@ interface Ledger {
 interface StreamLedger {
   fee_base: number
   fee_ref: number
-  ledger_hash: string
-  ledger_index: number
+  ledger_hash: LedgerHash
+  ledger_index: LedgerIndex
   ledger_time: number
   reserve_base: number
   reserve_inc: number
@@ -265,6 +268,8 @@ export {
   AgreementScore,
   Location,
   Ledger,
+  LedgerIndex,
+  LedgerHash,
   StreamLedger,
   Chain,
   ValidatorKeys,

--- a/test/chains/chains.test.ts
+++ b/test/chains/chains.test.ts
@@ -33,7 +33,8 @@ describe('Creates chains', () => {
       validators: Set<string>
     }> = chains.calculateChainsFromLedgers()
 
-    const ledgerHashes = constructed[0].ledgers.keys()
+    const ledgerHashes = Array.from(constructed[0].ledgers.keys())
+    console.log('hashes', ledgerHashes)
     expect(ledgerHashes).toContain('LEDGER1')
     expect(ledgerHashes).toContain('LEDGER2')
     expect(ledgerHashes).toContain('LEDGER3')

--- a/test/chains/chains.test.ts
+++ b/test/chains/chains.test.ts
@@ -34,7 +34,6 @@ describe('Creates chains', () => {
     }> = chains.calculateChainsFromLedgers()
 
     const ledgerHashes = Array.from(constructed[0].ledgers.keys())
-    console.log('hashes', ledgerHashes)
     expect(ledgerHashes).toContain('LEDGER1')
     expect(ledgerHashes).toContain('LEDGER2')
     expect(ledgerHashes).toContain('LEDGER3')

--- a/test/chains/chains.test.ts
+++ b/test/chains/chains.test.ts
@@ -1,5 +1,6 @@
 import chains from '../../src/connection-manager/chains'
 import { destroy, query, setupTables } from '../../src/shared/database'
+import { LedgerHash, LedgerIndex } from '../../src/shared/types'
 
 import validations from './fixtures/all-validations.json'
 
@@ -28,13 +29,14 @@ describe('Creates chains', () => {
     // Mock date.now
     Date.now = (): number => time
     const constructed: Array<{
-      ledgers: Set<string>
+      ledgers: Map<LedgerHash, LedgerIndex>
       validators: Set<string>
     }> = chains.calculateChainsFromLedgers()
 
-    expect(constructed[0].ledgers).toContain('LEDGER1')
-    expect(constructed[0].ledgers).toContain('LEDGER2')
-    expect(constructed[0].ledgers).toContain('LEDGER3')
+    const ledgerHashes = constructed[0].ledgers.keys()
+    expect(ledgerHashes).toContain('LEDGER1')
+    expect(ledgerHashes).toContain('LEDGER2')
+    expect(ledgerHashes).toContain('LEDGER3')
 
     expect(constructed[0].validators).toContain('VALIDATOR1')
     expect(constructed[0].validators).toContain('VALIDATOR2')
@@ -45,11 +47,11 @@ describe('Creates chains', () => {
     await chains.purgeChains()
 
     const constructed: Array<{
-      ledgers: Set<string>
+      ledgers: Map<LedgerHash, LedgerIndex>
       validators: Set<string>
     }> = chains.calculateChainsFromLedgers()
 
-    expect(constructed[0].ledgers).toEqual(new Set())
+    expect(constructed[0].ledgers).toEqual(new Map())
 
     expect(constructed[0].validators).toContain('VALIDATOR1')
     expect(constructed[0].validators).toContain('VALIDATOR2')

--- a/test/chains/single-validations.test.ts
+++ b/test/chains/single-validations.test.ts
@@ -1,5 +1,6 @@
 import chains from '../../src/connection-manager/chains'
 import { destroy, query, setupTables } from '../../src/shared/database'
+import { LedgerHash, LedgerIndex } from '../../src/shared/types'
 
 import singleValidations from './fixtures/single-validations.json'
 
@@ -28,7 +29,7 @@ describe('Single Validations', () => {
     // Mock date.now
     Date.now = (): number => time
     const constructed: Array<{
-      ledgers: Set<string>
+      ledgers: Map<LedgerHash, LedgerIndex>
       validators: Set<string>
     }> = chains.calculateChainsFromLedgers()
 


### PR DESCRIPTION
## High Level Overview of Change

I order to track down the cause of missed ledgers log when a validator misses

### Context of Change

Example message with a validation mismatch:
```Chain main had a validator (nHU4bLE3EmSqNwfL4AP1UZeTNPrSPPP6FXLKXo2uqfHuvBQxDVKd) miss a ledger (3051520) due to a mismatched hash of 04EF1BF397D40AD2298520E377FA919B03E97489D22B8924BC2C5A1585206D9E```

Example log message when no validation message was emitted:
```Chain main had a validator (nHU4bLE3EmSqNwfL4AP1UZeTNPrSPPP6FXLKXo2uqfHuvBQxDVKd) miss a ledger (3051520) due to no validation message```

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release