### PR TITLE
fix: validator report timestamp

### DIFF
--- a/src/api/routes/v1/validator-report.ts
+++ b/src/api/routes/v1/validator-report.ts
@@ -35,7 +35,7 @@ function formatResponse(response: DatabaseResponse): ScoreResponse {
   } = response
   const denominator = validated + missed
   const score: number = denominator === 0 ? 0 : validated / denominator
-  date.setHours(23, 0, 0, 0)
+  date.setHours(0, 0, 0, 0)
 
   return {
     validation_public_key: master_key,


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

There was a bug in response format for individual validator reports (`/validator/{pubkey}/reports`) that caused the date to be in the future for timezone later than UTC. Set the hour of the date to be 0 instead of 23 would fix this issue, and also correspond with how daily scores save their dates and the `/validator_reports`.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->
The effect of this change has been tested locally by changing browser's timezone


## Future Tasks

Date time on the Explorer should all be in UTC with a specified note to ensure consistency in the data that users in various regions see.