### PR TITLE
fix: move fetch amendments info to connections

### DIFF
--- a/src/connection-manager/connections.ts
+++ b/src/connection-manager/connections.ts
@@ -8,6 +8,7 @@ import {
   clearConnectionsDb,
   getNetworks,
 } from '../shared/database'
+import { fetchAmendmentInfo } from '../shared/database/amendments'
 import { FeeVote, LedgerResponseCorrected } from '../shared/types'
 import logger from '../shared/utils/logger'
 
@@ -207,6 +208,7 @@ setInterval(() => {
 export default async function startConnections(): Promise<void> {
   if (!cmStarted) {
     cmStarted = true
+    await fetchAmendmentInfo()
     await clearConnectionsDb()
     await createConnections()
     setInterval(() => {

--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -2,6 +2,7 @@ import 'dotenv/config'
 
 import Crawler from '../crawler/crawl'
 import { setupTables, getNetworks } from '../shared/database'
+import { fetchAmendmentInfo } from '../shared/database/amendments'
 
 import agreement from './agreement'
 import startConnections from './connections'
@@ -18,6 +19,7 @@ async function start(): Promise<void> {
     promises.push(crawler.crawl(network))
   }
   await Promise.all(promises)
+  await fetchAmendmentInfo()
   await startConnections()
   await doManifestJobs()
   agreement.start()

--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -2,7 +2,6 @@ import 'dotenv/config'
 
 import Crawler from '../crawler/crawl'
 import { setupTables, getNetworks } from '../shared/database'
-import { fetchAmendmentInfo } from '../shared/database/amendments'
 
 import agreement from './agreement'
 import startConnections from './connections'
@@ -19,7 +18,6 @@ async function start(): Promise<void> {
     promises.push(crawler.crawl(network))
   }
   await Promise.all(promises)
-  await fetchAmendmentInfo()
   await startConnections()
   await doManifestJobs()
   agreement.start()

--- a/src/shared/database/setup.ts
+++ b/src/shared/database/setup.ts
@@ -1,6 +1,5 @@
 import logger from '../utils/logger'
 
-import { fetchAmendmentInfo } from './amendments'
 import networks from './networks'
 import addAmendmentsDataFromJSON from './update-amendments-from-json'
 import { db, query } from './utils'
@@ -24,7 +23,6 @@ export default async function setupTables(): Promise<void> {
   await setupAmendmentsStatusTable()
   await setupAmendmentsInfoTable()
   await setupBallotTable()
-  await fetchAmendmentInfo()
   await addAmendmentsDataFromJSON()
 }
 


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

Move parsing and fetching amendments info from the 2 data sources to connections so that it runs every hour.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

The `fetchAmendmentInfo()` function is being used in `setupTables` which only run once per deployment. Move it to connections so that it runs every hour.
