### PR TITLE
fix: connections reconnect after inactivity

### DIFF
--- a/src/connection-manager/connections.ts
+++ b/src/connection-manager/connections.ts
@@ -64,6 +64,7 @@ async function setHandlers(
           const newWS = new WebSocket(ws.url, { handshakeTimeout: WS_TIMEOUT })
           // Clean up the old Websocket connection
           connections.delete(ip)
+          ws.close(1000, 'No activity in the last 5 minutes')
           ws.terminate()
           resolve()
 


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

On the VHS, even when a WebSocket connection is open, it stops receiving subscription messages for some periods and resumes. The issue has been raised here to the Core Ledger:
https://github.com/XRPLF/rippled/issues/3180
It happened more often for some nodes than others. One approach to fix it in the immediate term is to reconnect after the ws remains open but no message has arrived in 1 minute.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
