### PR TITLE
fix: `validators` api call mixed networks

### DIFF
--- a/src/api/routes/v1/utils.ts
+++ b/src/api/routes/v1/utils.ts
@@ -53,8 +53,8 @@ export async function formatAmendments(
 /**
  * Get param type from validator API call.
  *
- * @param param - The UNL/Networks of the chain.
- *
+ * @param param - The input parameter.
+ * @returns The type of the input parameter (unl/networks/unknown).
  */
 export async function getParamType(
   param: string | undefined,
@@ -70,7 +70,8 @@ export async function getParamType(
   })
   if (networks.includes(param)) {
     return 'networks'
-  } else if (unls.includes(param)) {
+  }
+  if (unls.includes(param)) {
     return 'unl'
   }
 

--- a/src/api/routes/v1/utils.ts
+++ b/src/api/routes/v1/utils.ts
@@ -51,15 +51,15 @@ export async function formatAmendments(
 }
 
 /**
- * Get the chains associated with the given UNL.
+ * Get param type from validator API call.
  *
  * @param param - The UNL/Networks of the chain.
- * @returns The chains associated with that UNL.
+ *
  */
-export async function getChains(
+export async function getParamType(
   param: string | undefined,
-): Promise<string[] | undefined> {
-  if (param == null) {
+): Promise<'networks' | 'unl' | undefined> {
+  if (!param) {
     return undefined
   }
   const networksDb = await getNetworks()
@@ -68,19 +68,25 @@ export async function getChains(
   networksDb.forEach((network) => {
     unls.push(...network.unls)
   })
-
-  let requestedField
   if (networks.includes(param)) {
-    requestedField = 'networks'
+    return 'networks'
   } else if (unls.includes(param)) {
-    requestedField = 'unl'
-  } else {
-    return []
+    return 'unl'
   }
 
+  return undefined
+}
+
+/**
+ * Get the chains associated with the given UNL.
+ *
+ * @param unl - The UNL of the chain.
+ * @returns The chains associated with that UNL.
+ */
+export async function getChains(unl: string): Promise<string[] | undefined> {
   const results = await query('validators')
     .select('chain')
     .distinct()
-    .where(requestedField, param)
+    .where('unl', unl)
   return results.map((result) => result.chain as string)
 }

--- a/src/api/routes/v1/validator.ts
+++ b/src/api/routes/v1/validator.ts
@@ -9,6 +9,7 @@ import {
   formatAgreementScore,
   formatAmendments,
   getChains,
+  getParamType,
 } from './utils'
 
 const log = logger({ name: 'api-validator' })
@@ -296,13 +297,26 @@ export async function handleValidators(
     }
 
     const { param } = req.params
-    const chains = await getChains(param)
-    const validators =
-      chains == null
-        ? cache.validators
-        : cache.validators.filter((validator) =>
-            chains.includes(validator.chain),
-          )
+    const paramType = await getParamType(param)
+
+    console.log(paramType)
+
+    let validators
+    if (paramType === 'networks') {
+      validators = cache.validators.filter(
+        (validator) => validator.networks === param,
+      )
+    } else if (paramType === 'unl') {
+      const chains = await getChains(param)
+      validators =
+        chains == null
+          ? cache.validators
+          : cache.validators.filter((validator) =>
+              chains.includes(validator.chain),
+            )
+    } else {
+      validators = cache.validators
+    }
 
     const response: ValidatorsResponse = {
       result: 'success',

--- a/src/api/routes/v1/validator.ts
+++ b/src/api/routes/v1/validator.ts
@@ -299,8 +299,6 @@ export async function handleValidators(
     const { param } = req.params
     const paramType = await getParamType(param)
 
-    console.log(paramType)
-
     let validators
     if (paramType === 'networks') {
       validators = cache.validators.filter(


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

Currently the `validators/{networks}` call still uses chain matching. This led to test validators get pulled to main when there's a test validator validates on main accidentally, and vice versa. 

for example: if after a leakage, a test validator has chain `main` and networks `test`, all of the mainnet validators will show up on `validators/test`, which is incorrect.

We should just use `networks` field for `validators/{networks}` itself to mitigate this effect, and also, `networks` is updated more frequently using `ledger_hash`, which makes it more accurate compared to chain calculation.

In the future, we should revise chain calculation and agreement score calculation since there's some minor issues there (will create a ticket for it). The inclusion of `network-id` on the validation stream would also be a permanent solution, but it is still WIP.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

Leakage should be fixed in staging
