### PR TITLE
fix amendments backtracking

### DIFF
--- a/src/connection-manager/wsHandling.ts
+++ b/src/connection-manager/wsHandling.ts
@@ -264,11 +264,15 @@ async function backtrackNetworkAmendmentStatus(
       index < currentLedger;
       index += 256
     ) {
+      // Use api V1 instead of the default (V2) since we don't have the correct
+      // LedgerResponseExpanded type for V2
+      // TODO: change to V2 once the issue is fixed.
       const ledger: LedgerResponse = await client.request({
         command: 'ledger',
         transactions: true,
         ledger_index: index,
         expand: true,
+        api_version: 1,
       })
 
       await handleWsMessageLedgerEnableAmendments(

--- a/src/shared/database/amendments.ts
+++ b/src/shared/database/amendments.ts
@@ -39,7 +39,7 @@ const AMENDMENT_VERSION_REGEX =
   /\| \[(?<amendmentName>[a-zA-Z0-9_]+)\][^\n]+\| (?<version>v[0-9]*\.[0-9]*\.[0-9]*|TBD) *\|/u
 
 export const NETWORKS_HOSTS = new Map([
-  ['main', 'ws://s2.ripple.com:51233'],
+  ['main', 'wss://xrplcluster.com'],
   ['test', 'wss://s.altnet.rippletest.net:51233'],
   ['dev', 'wss://s.devnet.rippletest.net:51233'],
 ])


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

There are 2 issues with amendment backtracking and status retrieval:
- `ledger` rpc for API v2 with `transactions` and `expand` enabled does not match `LedgerResponseExpanded` field on xrpl.js. Use v1 for now.
- s2 Clio often reached rate limit when backtracking amendments for mainnet. Use xrpl-cluster instead.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
