### PR TITLE
Exponential backoff before WebSocket connection retry

### DIFF
--- a/src/connection-manager/connections.ts
+++ b/src/connection-manager/connections.ts
@@ -59,6 +59,9 @@ async function setHandlers(
   const ledger_hashes: string[] = []
   return new Promise(function setHandlersPromise(resolve, _reject) {
     ws.on('open', () => {
+      if (networks === 'xahau-main') {
+        log.info(`Debug1 connection opened:${ws.url}`)
+      }
       if (connections.has(ip)) {
         resolve()
         return
@@ -78,6 +81,9 @@ async function setHandlers(
       resolve()
     })
     ws.on('message', function handleMessage(message: string) {
+      if (networks === 'xahau-main') {
+        log.info(`Debug1 data received:${ws.url}`)
+      }
       let data
       try {
         data = JSON.parse(message)
@@ -107,6 +113,13 @@ async function setHandlers(
       }
     })
     ws.on('close', async (code, reason) => {
+      if (networks === 'xahau-main') {
+        log.info(
+          `Debug1 connection closed:${ws.url}:${code}:${reason.toString(
+            'utf-8',
+          )}`,
+        )
+      }
       const nodeNetworks = networks ?? 'unknown network'
       if (connectionsInitialized) {
         log.error(
@@ -139,7 +152,10 @@ async function setHandlers(
       ws.terminate()
       resolve()
     })
-    ws.on('error', () => {
+    ws.on('error', (err) => {
+      if (networks === 'xahau-main') {
+        log.info(`Debug1 connection error:${ws.url}:${err.message}`)
+      }
       if (connections.get(ip)?.url === ws.url) {
         connections.delete(ip)
       }

--- a/src/connection-manager/connections.ts
+++ b/src/connection-manager/connections.ts
@@ -42,7 +42,6 @@ const MAX_DELAY = 30 * 1000 // 30 seconds
 //  1005: No Status Received: An empty or undefined status code is used to indicate no further details about the closure.
 // Reconnection should happen after seeing these codes for established connections.
 const CLOSING_CODES = [1005, 1006, 1008]
-let connectionsInitialized = false
 let cmStarted = false
 
 /**
@@ -262,12 +261,12 @@ async function createConnections(): Promise<void> {
   })
 
   const promises: Array<Promise<void>> = []
-  connectionsInitialized = false
+
   nodes.forEach((node: WsNode) => {
     promises.push(findConnection(node))
   })
   await Promise.all(promises)
-  connectionsInitialized = true
+
   log.info(`${connections.size} connections created`)
 }
 


### PR DESCRIPTION
## High Level Overview of Change

This change is being introduced to fix hourly agreement not being updated from xahau-main network. 

1. Added exponential backoff before WebSocket connection retries, so that the validator server is not swamped with connection requests and hopefully, our server's ip address is not blocked from any further requests.

2. Removed `connectionsInitialized` check from websockets `close` callback before retrying. Since, as per the current design of the code, if all the connections are not initialized and one of the connection (lets say wss://xahau.network/) closes , it won't be retried until next hour.


### Context of Change

To fix connection issue specifically for `wss://xahau.network/`

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

This issue occurs only in production. So, we will deploy this branch on staging and see if the intended fix do not cause any issue.

<!--
## Future Tasks
For future tasks related to PR.
-->
