### PR TITLE
fix: remove db access per validation for fee data

### DIFF
--- a/src/connection-manager/agreement.ts
+++ b/src/connection-manager/agreement.ts
@@ -123,10 +123,10 @@ function isPreceedingFlagLedger(ledger_index: string): boolean {
 }
 
 /**
- * Finds network name from chain id
+ * Finds network name from chain id.
  *
  * @param chain - A chain object.
- * @returns string.
+ * @returns String.
  */
 async function getNetworkNameFromChainId(chain: Chain): Promise<string> {
   let id = chain.id

--- a/src/connection-manager/agreement.ts
+++ b/src/connection-manager/agreement.ts
@@ -26,7 +26,7 @@ import chains from './chains'
 
 const log = logger({ name: 'agreement' })
 
-const AGREEMENT_INTERVAL = 0.5 * 60 * 1000
+const AGREEMENT_INTERVAL = 60 * 60 * 1000
 const PURGE_INTERVAL = 10 * 60 * 1000
 
 /**

--- a/src/connection-manager/agreement.ts
+++ b/src/connection-manager/agreement.ts
@@ -153,6 +153,10 @@ class Agreement {
     for (const chain of agreementChains) {
       const ledger_hashes = chain.ledgers
 
+      log.info(
+        `Agreement: ${chain.id}:${Array.from(chain.validators).join(',')}`,
+      )
+
       for (const signing_key of chain.validators) {
         promises.push(
           this.calculateValidatorAgreement(

--- a/src/connection-manager/agreement.ts
+++ b/src/connection-manager/agreement.ts
@@ -17,14 +17,16 @@ import {
   ValidationRaw,
   ValidatorKeys,
   Ballot,
+  Chain,
 } from '../shared/types'
+import { getLists, overlaps } from '../shared/utils'
 import logger from '../shared/utils/logger'
 
 import chains from './chains'
 
 const log = logger({ name: 'agreement' })
 
-const AGREEMENT_INTERVAL = 60 * 60 * 1000
+const AGREEMENT_INTERVAL = 0.5 * 60 * 1000
 const PURGE_INTERVAL = 10 * 60 * 1000
 
 /**
@@ -121,6 +123,30 @@ function isPreceedingFlagLedger(ledger_index: string): boolean {
 }
 
 /**
+ * Finds network name from chain id
+ *
+ * @param chain - A chain object.
+ * @returns string.
+ */
+async function getNetworkNameFromChainId(chain: Chain): Promise<string> {
+  let id = chain.id
+  const lists = await getLists().catch((err) => {
+    log.error('Error getting validator lists', err)
+    return undefined
+  })
+
+  if (lists != null) {
+    Object.entries(lists).forEach(([network, set]) => {
+      if (overlaps(chain.validators, set)) {
+        id = network
+      }
+    })
+  }
+
+  return id
+}
+
+/**
  *
  */
 class Agreement {
@@ -153,8 +179,12 @@ class Agreement {
     for (const chain of agreementChains) {
       const ledger_hashes = chain.ledgers
 
+      const networkName = await getNetworkNameFromChainId(chain)
+
       log.info(
-        `Agreement: ${chain.id}:${Array.from(chain.validators).join(',')}`,
+        `Agreement: ${chain.id}:${networkName}:${Array.from(
+          chain.validators,
+        ).join(',')}`,
       )
 
       for (const signing_key of chain.validators) {

--- a/src/connection-manager/connections.ts
+++ b/src/connection-manager/connections.ts
@@ -61,12 +61,6 @@ async function setHandlers(
   isInitialNode = false,
   retryCount = 0,
 ): Promise<void> {
-  // log.info(
-  //   `Initiated Websocket connection for: ${ws_url} on ${
-  //     networks ?? 'unknown network'
-  //   }`,
-  // )
-
   const ledger_hashes: string[] = []
   return new Promise(function setHandlersPromise(resolve, _reject) {
     ws.on('open', () => {
@@ -124,21 +118,21 @@ async function setHandlers(
         )
       }
     })
-    ws.on('close', async (code) => {
-      // log.error(
-      //   `Websocket closed for ${ws.url} on ${
-      //     networks ?? 'unknown network'
-      //   } with code ${code} and reason ${reason.toString('utf-8')}.`,
-      // )
+    ws.on('close', async (code, reason) => {
+      log.error(
+        `Websocket closed for ${ws.url} on ${
+          networks ?? 'unknown network'
+        } with code ${code} and reason ${reason.toString('utf-8')}.`,
+      )
 
       const delay = BASE_RETRY_DELAY * 2 ** retryCount
 
       if (CLOSING_CODES.includes(code) && delay <= MAX_RETRY_DELAY) {
-        // log.info(
-        //   `Reconnecting to ${ws.url} on ${
-        //     networks ?? 'unknown network'
-        //   } after ${delay}ms...`,
-        // )
+        log.info(
+          `Reconnecting to ${ws.url} on ${
+            networks ?? 'unknown network'
+          } after ${delay}ms...`,
+        )
         // Clean up the old Websocket connection
         connections.delete(ws.url)
         ws.terminate()
@@ -168,12 +162,12 @@ async function setHandlers(
       ws.terminate()
       resolve()
     })
-    ws.on('error', () => {
-      // log.error(
-      //   `Websocket connection error for ${ws.url} on ${
-      //     networks ?? 'unknown network'
-      //   } - ${err.message}`,
-      // )
+    ws.on('error', (err) => {
+      log.error(
+        `Websocket connection error for ${ws.url} on ${
+          networks ?? 'unknown network'
+        } - ${err.message}`,
+      )
 
       if (connections.get(ws.url)?.url === ws.url) {
         connections.delete(ws.url)

--- a/src/connection-manager/connections.ts
+++ b/src/connection-manager/connections.ts
@@ -124,7 +124,7 @@ async function setHandlers(
         )
       }
     })
-    ws.on('close', async (code, reason) => {
+    ws.on('close', async (code) => {
       // log.error(
       //   `Websocket closed for ${ws.url} on ${
       //     networks ?? 'unknown network'
@@ -168,7 +168,7 @@ async function setHandlers(
       ws.terminate()
       resolve()
     })
-    ws.on('error', (err) => {
+    ws.on('error', () => {
       // log.error(
       //   `Websocket connection error for ${ws.url} on ${
       //     networks ?? 'unknown network'

--- a/src/connection-manager/wsHandling.ts
+++ b/src/connection-manager/wsHandling.ts
@@ -9,18 +9,13 @@ import {
 import { AMENDMENTS_ID } from 'xrpl/dist/npm/models/ledger'
 import { LedgerResponseExpanded } from 'xrpl/dist/npm/models/methods/ledger'
 
-import {
-  query,
-  saveAmendmentStatus,
-  saveAmendmentsStatus,
-} from '../shared/database'
+import { saveAmendmentStatus, saveAmendmentsStatus } from '../shared/database'
 import {
   NETWORKS_HOSTS,
   deleteAmendmentStatus,
 } from '../shared/database/amendments'
 import {
   AmendmentStatus,
-  DatabaseValidator,
   FeeVote,
   StreamLedger,
   StreamManifest,

--- a/src/connection-manager/wsHandling.ts
+++ b/src/connection-manager/wsHandling.ts
@@ -101,7 +101,7 @@ function isFlagLedgerPlusOne(ledger_index: number): boolean {
  * @param networks - The networks of subscribed node.
  * @param network_fee - The map of default fee for the network to be used in case the validator does not vote for a new fee.
  * @param ws - The WebSocket message received from.
- * @param validationNetworkDb -- The validation network map to fetch fee data.
+ * @param validationNetworkDb -- A map of validator signing_keys to their corresponding networks.
  * @returns Void.
  */
 // eslint-disable-next-line max-params -- Disabled for this function.

--- a/src/connection-manager/wsHandling.ts
+++ b/src/connection-manager/wsHandling.ts
@@ -106,6 +106,7 @@ function isFlagLedgerPlusOne(ledger_index: number): boolean {
  * @param networks - The networks of subscribed node.
  * @param network_fee - The map of default fee for the network to be used in case the validator does not vote for a new fee.
  * @param ws - The WebSocket message received from.
+ * @param validationNetworkDb -- The validation network map to fetch fee data.
  * @returns Void.
  */
 // eslint-disable-next-line max-params -- Disabled for this function.
@@ -115,6 +116,7 @@ export async function handleWsMessageSubscribeTypes(
   networks: string | undefined,
   network_fee: Map<string, FeeVote>,
   ws: WebSocket,
+  validationNetworkDb: Map<string, string>,
 ): Promise<void> {
   if (data.type === 'validationReceived') {
     const validationData = data as ValidationRaw
@@ -122,15 +124,9 @@ export async function handleWsMessageSubscribeTypes(
       validationData.networks = networks
     }
 
-    // Get network of the validation if ledger_hash is not in cache.
-    const validationNetworkDb: DatabaseValidator | undefined = await query(
-      'validators',
-    )
-      .select('*')
-      .where('signing_key', validationData.validation_public_key)
-      .first()
     const validationNetwork =
-      validationNetworkDb?.networks ?? validationData.networks
+      validationNetworkDb.get(validationData.validation_public_key) ??
+      validationData.networks
 
     // Get the fee for the network to be used in case the validator does not vote for a new fee.
     if (validationNetwork) {


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->
The validator table in database is being queried every time there's a new validation to retrieve fee data, which caused this error:
`KnexTimeoutError: Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?`
We can instead cache this validator-network data and update it every hour to reduce number of queries.


### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
