### PR TITLE
Fix metrics endpoint

### DIFF
--- a/src/api/routes/v1/health.ts
+++ b/src/api/routes/v1/health.ts
@@ -50,7 +50,9 @@ export async function handleMonitoringMetrics(
       result.map((row) => [row.network, Number(row.count)]),
     )
 
-    const allNetworks = (await query('networks').select('id')) as Array<{
+    const allNetworks = (await query('networks')
+      .select('id')
+      .orderBy('id')) as Array<{
       id: string
     }>
 

--- a/test/api/health.test.ts
+++ b/test/api/health.test.ts
@@ -47,6 +47,15 @@ describe('connections health', () => {
 
     await flushPromises()
 
-    expect(resp.send).toHaveBeenCalled()
+    const expectedLines = [
+      'connected_nodes{network="amm-dev"} 0',
+      'connected_nodes{network="dev"} 0',
+      'connected_nodes{network="main"} 2',
+      'connected_nodes{network="test"} 0',
+      'connected_nodes{network="xahau-main"} 1',
+      'connected_nodes{network="xahau-test"} 0',
+    ]
+
+    expect(resp.send).toHaveBeenCalledWith(expectedLines.join('\n'))
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Fix `v1/metrics` endpoint to always return a network row, even if there are no active connections. It would return a row with 0 count.
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
This would prevent `DatasourceNoData` Grafana alerts.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After
The API response remains the same.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Added unit test case.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
