### PR TITLE
fix: validator reports for validators without a master key

### DIFF
--- a/src/api/routes/v1/validator-report.ts
+++ b/src/api/routes/v1/validator-report.ts
@@ -1,10 +1,15 @@
 import { Request, Response } from 'express'
 
-import { query } from '../../../shared/database'
+import { db, query } from '../../../shared/database'
 import { AgreementScore } from '../../../shared/types'
 import logger from '../../../shared/utils/logger'
 
 const log = logger({ name: 'api-validator-report' })
+
+// Agreement rows are keyed by `master_key ?? signing_key` (see
+// `saveDailyAgreement` in the connection-manager), so reads must resolve a
+// validator to that same effective key.
+const EFFECTIVE_KEY = 'COALESCE(validators.master_key, validators.signing_key)'
 
 interface ScoreResponse {
   validation_public_key: string
@@ -54,23 +59,29 @@ function formatResponse(response: DatabaseResponse): ScoreResponse {
 /**
  * Gets all daily score reports for a validator.
  *
- * @param master_key - Master key of validator.
+ * Accepts either a master key or a signing key, matching the behavior of the
+ * validator endpoint. Validators that never published a manifest have a null
+ * `master_key` and are only reachable by their signing key.
+ *
+ * @param public_key - Master key or signing key of validator.
  * @returns A promise that resolves to an array of ScoreResponse.
  */
-async function getReports(master_key: string): Promise<ScoreResponse[]> {
+async function getReports(public_key: string): Promise<ScoreResponse[]> {
   return query('daily_agreement')
     .select([
-      'validators.master_key',
+      db().raw(`${EFFECTIVE_KEY} as master_key`),
       'daily_agreement.day as date',
       'validators.chain',
       'daily_agreement.agreement',
     ])
-    .innerJoin(
-      'validators',
-      'daily_agreement.main_key',
-      'validators.master_key',
-    )
-    .where('validators.master_key', '=', master_key)
+    .innerJoin('validators', (join) => {
+      join.on(db().raw(`daily_agreement.main_key = ${EFFECTIVE_KEY}`))
+    })
+    .where((builder) => {
+      builder
+        .where('validators.master_key', '=', public_key)
+        .orWhere('validators.signing_key', '=', public_key)
+    })
     .andWhere('validators.revoked', '=', 'false')
     .then((resp: DatabaseResponse[]) => resp.map(formatResponse))
 }
@@ -87,8 +98,8 @@ export default async function handleValidatorReport(
   res: Response,
 ): Promise<void> {
   try {
-    const master_key = req.params.publicKey
-    const scores: ScoreResponse[] = await getReports(master_key)
+    const public_key = req.params.publicKey
+    const scores: ScoreResponse[] = await getReports(public_key)
 
     const response = {
       result: 'success',

--- a/test/api/validator-report.test.ts
+++ b/test/api/validator-report.test.ts
@@ -1,0 +1,136 @@
+import { Request, Response } from 'express'
+
+import handleValidatorReport from '../../src/api/routes/v1/validator-report'
+import { destroy, query, setupTables } from '../../src/shared/database'
+
+// Validator that never published a manifest, so it has no master key.
+const NO_MASTER_SIGNING_KEY =
+  'n9LS8sE7BCxYFJKC2eR3dFLGLRu7KYq2s88z1irdUTUkha4qWv4q'
+// Validator with a manifest, so its agreement rows are keyed by master key.
+const MASTER_KEY = 'nHUon2tpyJEHrb55CQ1sTYZFJvmsBvjcxfE7NLzczCmYAM7X4c1s'
+const MASTER_SIGNING_KEY =
+  'n9M2anhK2HzFFiJZRoGKhyLpkh55ZdeWw8YyGgvkzN7rgQEcTLPq'
+// Revoked validator, which should be excluded from reports.
+const REVOKED_MASTER_KEY =
+  'nHBidG3pZK11zQD6kpNDoAhDxH6WLGui6ZxSbUx7LSqLHsgzMPec'
+
+const DAY = new Date('2026-09-01T00:00:00.000Z')
+
+const validators = [
+  {
+    master_key: null,
+    signing_key: NO_MASTER_SIGNING_KEY,
+    revoked: false,
+    chain: 'main',
+    networks: 'main',
+  },
+  {
+    master_key: MASTER_KEY,
+    signing_key: MASTER_SIGNING_KEY,
+    revoked: false,
+    chain: 'main',
+    networks: 'main',
+  },
+  {
+    master_key: REVOKED_MASTER_KEY,
+    signing_key: 'n9KaxgJv69FucW5kkiaMhCqS6sAR1wUVxpZaZmLGVXxAcAse9YhR',
+    revoked: true,
+    chain: 'main',
+    networks: 'main',
+  },
+]
+
+// saveDailyAgreement keys rows by `master_key ?? signing_key`.
+const dailyAgreements = [
+  {
+    main_key: NO_MASTER_SIGNING_KEY,
+    day: DAY,
+    agreement: JSON.stringify({ validated: 90, missed: 10, incomplete: false }),
+  },
+  {
+    main_key: MASTER_KEY,
+    day: DAY,
+    agreement: JSON.stringify({ validated: 75, missed: 25, incomplete: false }),
+  },
+  {
+    main_key: REVOKED_MASTER_KEY,
+    day: DAY,
+    agreement: JSON.stringify({ validated: 50, missed: 50, incomplete: false }),
+  },
+]
+
+interface ReportsBody {
+  count: number
+  reports: Array<{ validation_public_key: string; score: string }>
+}
+
+/**
+ * Invokes the reports handler and returns what it sent.
+ *
+ * @param publicKey - Key to request reports for.
+ * @returns The response body passed to res.send.
+ */
+async function getReportsFor(publicKey: string): Promise<ReportsBody> {
+  const req = { params: { publicKey } } as unknown as Request
+  const send = jest.fn<undefined, [ReportsBody]>()
+  const res = {
+    send,
+    status: jest.fn().mockReturnThis(),
+  } as unknown as Response
+
+  await handleValidatorReport(req, res)
+
+  return send.mock.calls[0][0]
+}
+
+describe('tests for validator reports endpoint', () => {
+  beforeAll(async () => {
+    await setupTables()
+    await query('validators').delete('*')
+    await query('daily_agreement').delete('*')
+    await query('validators').insert(validators)
+    await query('daily_agreement').insert(dailyAgreements)
+  })
+
+  afterAll(async () => {
+    await query('validators').delete('*')
+    await query('daily_agreement').delete('*')
+    await destroy()
+  })
+
+  it('returns reports for a validator with no master key, by signing key', async () => {
+    const body = await getReportsFor(NO_MASTER_SIGNING_KEY)
+
+    expect(body.count).toBe(1)
+    expect(body.reports[0].validation_public_key).toBe(NO_MASTER_SIGNING_KEY)
+    expect(body.reports[0].score).toBe('0.90000')
+  })
+
+  it('returns reports for a validator looked up by its master key', async () => {
+    const body = await getReportsFor(MASTER_KEY)
+
+    expect(body.count).toBe(1)
+    expect(body.reports[0].validation_public_key).toBe(MASTER_KEY)
+    expect(body.reports[0].score).toBe('0.75000')
+  })
+
+  it('returns reports for a validator looked up by its signing key', async () => {
+    const body = await getReportsFor(MASTER_SIGNING_KEY)
+
+    expect(body.count).toBe(1)
+    expect(body.reports[0].validation_public_key).toBe(MASTER_KEY)
+    expect(body.reports[0].score).toBe('0.75000')
+  })
+
+  it('excludes revoked validators', async () => {
+    const body = await getReportsFor(REVOKED_MASTER_KEY)
+
+    expect(body.count).toBe(0)
+  })
+
+  it('returns no reports for an unknown key', async () => {
+    const body = await getReportsFor('n9UnknownKeyThatDoesNotExistAnywhere')
+
+    expect(body.count).toBe(0)
+  })
+})


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->
For `/reports` endpoint for validator:

- Join on `COALESCE(validators.master_key, validators.signing_key)`
- Match `master_key` or `signing_key`, mirroring `findInDatabase` in `validator.ts`

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

`GET /v1/network/validator/:publicKey/reports` returned `count: 0` for validators that never published a manifest, even though their agreement data exists.

Agreement rows are **written** keyed by `master_key ?? signing_key` (`saveDailyAgreement`, `src/connection-manager/agreement.ts`), but were **read** keyed on `master_key` alone:

```ts
.innerJoin('validators', 'daily_agreement.main_key', 'validators.master_key')
.where('validators.master_key', '=', master_key)
```

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

- `reports` shows up for validator without manifest on dev (https://vhs.dev.ripplex.io/v1/network/validator/n9LS8sE7BCxYFJKC2eR3dFLGLRu7KYq2s88z1irdUTUkha4qWv4q/reports) 
